### PR TITLE
Add NumericUpDown control

### DIFF
--- a/src/Fabulous.Avalonia/Attributes.fs
+++ b/src/Fabulous.Avalonia/Attributes.fs
@@ -67,6 +67,22 @@ module Attributes =
             | ValueNone -> target.ClearValue(directProperty)
             | ValueSome v -> target.SetValue(directProperty, v) |> ignore)
 
+    /// Define an attribute for an AvaloniaProperty supporting equality comparison and converter
+    let inline defineAvaloniaPropertyWithEqualityConverter<'T, 'modelType, 'valueType when 'T: equality>
+        (directProperty: AvaloniaProperty<'T>)
+        (convert: 'modelType -> 'valueType)
+        =
+        Attributes.defineScalar<'modelType, 'valueType>
+            directProperty.Name
+            convert
+            ScalarAttributeComparers.noCompare
+            (fun _ newValueOpt node ->
+                let target = node.Target :?> IAvaloniaObject
+
+                match newValueOpt with
+                | ValueNone -> target.ClearValue(directProperty)
+                | ValueSome v -> target.SetValue(directProperty, v) |> ignore)
+
     /// Define an attribute storing a collection of Widget for a AvaloniaList<T> property
     let defineAvaloniaListWidgetCollection<'itemType> name (getCollection: obj -> IAvaloniaList<'itemType>) =
         let applyDiff _ (diffs: WidgetCollectionItemChanges) (node: IViewNode) =

--- a/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
+++ b/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
@@ -100,6 +100,7 @@
     <Compile Include="Widgets\Controls\Button.fs" />
     <Compile Include="Widgets\Controls\Border.fs" />
     <Compile Include="Widgets\Controls\CheckBox.fs" />
+    <Compile Include="Widgets\Controls\NumericUpDown.fs" />
     <Compile Include="Widgets\Controls\ScrollViewer.fs" />
     <Compile Include="Widgets\Controls\DatePicker.fs" />
     <Compile Include="Widgets\Controls\TimePicker.fs" />

--- a/src/Fabulous.Avalonia/Widgets/Controls/NumericUpDown.fs
+++ b/src/Fabulous.Avalonia/Widgets/Controls/NumericUpDown.fs
@@ -1,10 +1,11 @@
 ﻿namespace Fabulous.Avalonia
 
-open System.Runtime.CompilerServices
 open Avalonia.Controls
+open Avalonia.Data.Converters
+open Avalonia.Layout
 open Fabulous
-open System
-open Avalonia.Interactivity
+open System.Globalization
+open System.Runtime.CompilerServices
 
 type IFabNumericUpDown =
     inherit IFabTemplatedControl
@@ -60,20 +61,20 @@ module NumericUpDown =
         Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.WatermarkProperty
 
     let Value =
-        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.ValueProperty
+        Attributes.defineAvaloniaPropertyWithEqualityConverter NumericUpDown.ValueProperty Option.toNullable
 
     let ValueChanged =
-        Attributes.defineAvaloniaPropertyWithChangedEvent' "NumericUpDown_ValueChanged" NumericUpDown.ValueProperty
-
-    let LostFocus =
-        Attributes.defineEvent<RoutedEventArgs> "NumericUpDown_LostFocus" (fun target ->
-            (target :?> NumericUpDown).LostFocus)
+        Attributes.defineAvaloniaPropertyWithChangedEvent
+            "NumericUpDown_ValueChanged"
+            NumericUpDown.ValueProperty
+            Option.toNullable
+            Option.ofNullable
 
 [<AutoOpen>]
 module NumericUpDownBuilders =
     type Fabulous.Avalonia.View with
 
-        static member inline NumericUpDown<'msg>(value: Nullable<decimal>, valueChanged: Nullable<decimal> -> 'msg) =
+        static member inline NumericUpDown<'msg>(value: decimal option, valueChanged: decimal option -> 'msg) =
             WidgetBuilder<'msg, IFabNumericUpDown>(
                 NumericUpDown.WidgetKey,
                 NumericUpDown.Value.WithValue(value),
@@ -103,7 +104,7 @@ type NumericUpDownModifiers =
     static member inline horizontalContentAlignment
         (
             this: WidgetBuilder<'msg, #IFabNumericUpDown>,
-            value: Avalonia.Layout.HorizontalAlignment
+            value: HorizontalAlignment
         ) =
         this.AddScalar(NumericUpDown.HorizontalContentAlignment.WithValue(value))
 
@@ -111,7 +112,7 @@ type NumericUpDownModifiers =
     static member inline verticalContentAlignment
         (
             this: WidgetBuilder<'msg, #IFabNumericUpDown>,
-            value: Avalonia.Layout.VerticalAlignment
+            value: VerticalAlignment
         ) =
         this.AddScalar(NumericUpDown.VerticalContentAlignment.WithValue(value))
 
@@ -132,19 +133,11 @@ type NumericUpDownModifiers =
         this.AddScalar(NumericUpDown.Minimum.WithValue(value))
 
     [<Extension>]
-    static member inline numberFormat
-        (
-            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
-            value: System.Globalization.NumberFormatInfo
-        ) =
+    static member inline numberFormat(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: NumberFormatInfo) =
         this.AddScalar(NumericUpDown.NumberFormat.WithValue(value))
 
     [<Extension>]
-    static member inline parsingNumberStyle
-        (
-            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
-            value: System.Globalization.NumberStyles
-        ) =
+    static member inline parsingNumberStyle(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: NumberStyles) =
         this.AddScalar(NumericUpDown.ParsingNumberStyle.WithValue(value))
 
     [<Extension>]
@@ -156,21 +149,9 @@ type NumericUpDownModifiers =
         this.AddScalar(NumericUpDown.Text.WithValue(value))
 
     [<Extension>]
-    static member inline textConverter
-        (
-            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
-            value: Avalonia.Data.Converters.IValueConverter
-        ) =
+    static member inline textConverter(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: IValueConverter) =
         this.AddScalar(NumericUpDown.TextConverter.WithValue(value))
 
     [<Extension>]
     static member inline watermark(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: string) =
         this.AddScalar(NumericUpDown.Watermark.WithValue(value))
-
-    [<Extension>]
-    static member inline onLostFocus
-        (
-            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
-            onLostFocus: RoutedEventArgs -> 'msg
-        ) =
-        this.AddScalar(NumericUpDown.LostFocus.WithValue(fun args -> onLostFocus args |> box))

--- a/src/Fabulous.Avalonia/Widgets/Controls/NumericUpDown.fs
+++ b/src/Fabulous.Avalonia/Widgets/Controls/NumericUpDown.fs
@@ -1,0 +1,176 @@
+﻿namespace Fabulous.Avalonia
+
+open System.Runtime.CompilerServices
+open Avalonia.Controls
+open Fabulous
+open System
+open Avalonia.Interactivity
+
+type IFabNumericUpDown =
+    inherit IFabTemplatedControl
+
+module NumericUpDown =
+    let WidgetKey = Widgets.register<NumericUpDown> ()
+
+    let AllowSpin =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.AllowSpinProperty
+
+    let ButtonSpinnerLocation =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.ButtonSpinnerLocationProperty
+
+    let ClipValueToMinMax =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.ClipValueToMinMaxProperty
+
+    let FormatString =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.FormatStringProperty
+
+    let HorizontalContentAlignment =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.HorizontalContentAlignmentProperty
+
+    let VerticalContentAlignment =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.VerticalContentAlignmentProperty
+
+    let Increment =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.IncrementProperty
+
+    let IsReadOnly =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.IsReadOnlyProperty
+
+    let Maximum =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.MaximumProperty
+
+    let Minimum =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.MinimumProperty
+
+    let NumberFormat =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.NumberFormatProperty
+
+    let ParsingNumberStyle =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.ParsingNumberStyleProperty
+
+    let ShowButtonSpinner =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.ShowButtonSpinnerProperty
+
+    let Text = Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.TextProperty
+
+    let TextConverter =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.TextConverterProperty
+
+    let Watermark =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.WatermarkProperty
+
+    let Value =
+        Attributes.defineAvaloniaPropertyWithEquality NumericUpDown.ValueProperty
+
+    let ValueChanged =
+        Attributes.defineAvaloniaPropertyWithChangedEvent' "NumericUpDown_ValueChanged" NumericUpDown.ValueProperty
+
+    let LostFocus =
+        Attributes.defineEvent<RoutedEventArgs> "NumericUpDown_LostFocus" (fun target ->
+            (target :?> NumericUpDown).LostFocus)
+
+[<AutoOpen>]
+module NumericUpDownBuilders =
+    type Fabulous.Avalonia.View with
+
+        static member inline NumericUpDown<'msg>(value: Nullable<decimal>, valueChanged: Nullable<decimal> -> 'msg) =
+            WidgetBuilder<'msg, IFabNumericUpDown>(
+                NumericUpDown.WidgetKey,
+                NumericUpDown.Value.WithValue(value),
+                NumericUpDown.ValueChanged.WithValue(ValueEventData.create value (fun args -> valueChanged args |> box))
+            )
+
+[<Extension>]
+type NumericUpDownModifiers =
+
+    [<Extension>]
+    static member inline allowSpin(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: bool) =
+        this.AddScalar(NumericUpDown.AllowSpin.WithValue(value))
+
+    [<Extension>]
+    static member inline buttonSpinnerLocation(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: Location) =
+        this.AddScalar(NumericUpDown.ButtonSpinnerLocation.WithValue(value))
+
+    [<Extension>]
+    static member inline clipValueToMinMax(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: bool) =
+        this.AddScalar(NumericUpDown.ClipValueToMinMax.WithValue(value))
+
+    [<Extension>]
+    static member inline formatString(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: string) =
+        this.AddScalar(NumericUpDown.FormatString.WithValue(value))
+
+    [<Extension>]
+    static member inline horizontalContentAlignment
+        (
+            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
+            value: Avalonia.Layout.HorizontalAlignment
+        ) =
+        this.AddScalar(NumericUpDown.HorizontalContentAlignment.WithValue(value))
+
+    [<Extension>]
+    static member inline verticalContentAlignment
+        (
+            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
+            value: Avalonia.Layout.VerticalAlignment
+        ) =
+        this.AddScalar(NumericUpDown.VerticalContentAlignment.WithValue(value))
+
+    [<Extension>]
+    static member inline increment(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: decimal) =
+        this.AddScalar(NumericUpDown.Increment.WithValue(value))
+
+    [<Extension>]
+    static member inline isReadOnly(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: bool) =
+        this.AddScalar(NumericUpDown.IsReadOnly.WithValue(value))
+
+    [<Extension>]
+    static member inline maximum(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: decimal) =
+        this.AddScalar(NumericUpDown.Maximum.WithValue(value))
+
+    [<Extension>]
+    static member inline minimum(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: decimal) =
+        this.AddScalar(NumericUpDown.Minimum.WithValue(value))
+
+    [<Extension>]
+    static member inline numberFormat
+        (
+            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
+            value: System.Globalization.NumberFormatInfo
+        ) =
+        this.AddScalar(NumericUpDown.NumberFormat.WithValue(value))
+
+    [<Extension>]
+    static member inline parsingNumberStyle
+        (
+            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
+            value: System.Globalization.NumberStyles
+        ) =
+        this.AddScalar(NumericUpDown.ParsingNumberStyle.WithValue(value))
+
+    [<Extension>]
+    static member inline showButtonSpinner(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: bool) =
+        this.AddScalar(NumericUpDown.ShowButtonSpinner.WithValue(value))
+
+    [<Extension>]
+    static member inline text(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: string) =
+        this.AddScalar(NumericUpDown.Text.WithValue(value))
+
+    [<Extension>]
+    static member inline textConverter
+        (
+            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
+            value: Avalonia.Data.Converters.IValueConverter
+        ) =
+        this.AddScalar(NumericUpDown.TextConverter.WithValue(value))
+
+    [<Extension>]
+    static member inline watermark(this: WidgetBuilder<'msg, #IFabNumericUpDown>, value: string) =
+        this.AddScalar(NumericUpDown.Watermark.WithValue(value))
+
+    [<Extension>]
+    static member inline onLostFocus
+        (
+            this: WidgetBuilder<'msg, #IFabNumericUpDown>,
+            onLostFocus: RoutedEventArgs -> 'msg
+        ) =
+        this.AddScalar(NumericUpDown.LostFocus.WithValue(fun args -> onLostFocus args |> box))


### PR DESCRIPTION
Note that the Value property is of type Nullable<decimal>, since the underlying Avalonia control was recently reworked to treat an empty entry as null (https://github.com/AvaloniaUI/Avalonia/pull/8259). 

In a Fabulous context, is a nullable Value property the desired behavior for this control? Unlike the Date and Time picker controls, a non-nullable value for NumericUpDown cannot be enforced solely by the constructor, since the user has the option to manually clear the input via keyboard entry. (Note also that watermark visibility is contingent on the Value property being nullable.) 