### PR TITLE
Fix multiple attribute registrations for same ListBox_Items

### DIFF
--- a/samples/Gallery/App.fs
+++ b/samples/Gallery/App.fs
@@ -47,16 +47,13 @@ module App =
                 let m, c = WidgetPage.update msg widgetModel
                 { model with WidgetModel = Some m }, (Cmd.map WidgetPageMsg c)
         | ItemSelected index ->
-            if index = - 1 then
-                model, Cmd.none
-            else
-                let model =
-                    { model with
-                        WidgetModel = Some(WidgetPage.init index)
-                        SelectedIndex = index
-                        IsPanOpen = true }
+            let model =
+                { model with
+                    WidgetModel = Some(WidgetPage.init index)
+                    SelectedIndex = index
+                    IsPanOpen = true }
 
-                model, Cmd.none
+            model, Cmd.none
 
         | OpenPanChanged x -> { model with IsPanOpen = x }, Cmd.none
 

--- a/src/Fabulous.Avalonia/Widgets.fs
+++ b/src/Fabulous.Avalonia/Widgets.fs
@@ -1,7 +1,7 @@
 namespace Fabulous.Avalonia
 
 open System
-open System.Collections.Generic
+open System.Collections
 open Avalonia
 open Fabulous
 open Fabulous.ScalarAttributeDefinitions
@@ -17,9 +17,9 @@ type IFabElement =
     interface
     end
 
-type WidgetItems<'T> =
-    { OriginalItems: IEnumerable<'T>
-      Template: 'T -> Widget }
+type WidgetItems =
+    { OriginalItems: IEnumerable
+      Template: obj -> Widget }
 
 module Widgets =
     let registerWithFactory<'T when 'T :> IAvaloniaObject> (factory: unit -> 'T) =
@@ -84,7 +84,7 @@ module WidgetHelpers =
 
     let buildItems<'msg, 'marker, 'itemData, 'itemMarker>
         key
-        (attrDef: SimpleScalarAttributeDefinition<WidgetItems<'itemData>>)
+        (attrDef: SimpleScalarAttributeDefinition<WidgetItems>)
         (items: seq<'itemData>)
         (itemTemplate: 'itemData -> WidgetBuilder<'msg, 'itemMarker>)
         =
@@ -92,7 +92,7 @@ module WidgetHelpers =
             let item = unbox<'itemData> item
             (itemTemplate item).Compile()
 
-        let data: WidgetItems<'itemData> =
+        let data: WidgetItems =
             { OriginalItems = items
               Template = template }
 

--- a/src/Fabulous.Avalonia/Widgets/Controls/ListBox.fs
+++ b/src/Fabulous.Avalonia/Widgets/Controls/ListBox.fs
@@ -10,8 +10,8 @@ type IFabListBox =
 module ListBox =
     let WidgetKey = Widgets.register<ListBox> ()
 
-    let ItemsSource<'T> =
-        Attributes.defineSimpleScalar<WidgetItems<'T>>
+    let ItemsSource =
+        Attributes.defineSimpleScalar<WidgetItems>
             "ListBox_Items"
             (fun a b -> ScalarAttributeComparers.equalityCompare a.OriginalItems b.OriginalItems)
             (fun _ newValueOpt node ->
@@ -42,8 +42,7 @@ module ListBox =
 module ListBoxBuilders =
     type Fabulous.Avalonia.View with
 
-        static member inline ListBox<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabListBoxItem>
-            (items: seq<'itemData>)
+        static member inline ListBox<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabListBoxItem> (items: seq<'itemData>)
             =
             WidgetHelpers.buildItems<'msg, IFabListBox, 'itemData, 'itemMarker>
                 ListBox.WidgetKey

--- a/src/Fabulous.Avalonia/Widgets/Controls/ListBox.fs
+++ b/src/Fabulous.Avalonia/Widgets/Controls/ListBox.fs
@@ -42,7 +42,8 @@ module ListBox =
 module ListBoxBuilders =
     type Fabulous.Avalonia.View with
 
-        static member inline ListBox<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabListBoxItem> (items: seq<'itemData>)
+        static member inline ListBox<'msg, 'itemData, 'itemMarker when 'itemMarker :> IFabListBoxItem>
+            (items: seq<'itemData>)
             =
             WidgetHelpers.buildItems<'msg, IFabListBox, 'itemData, 'itemMarker>
                 ListBox.WidgetKey


### PR DESCRIPTION
Noticed an issue with the ListBox.

Every time you select a different item on the ListBox, it was triggering ItemSelected twice: one with the correct item selected, one with index = -1.

I tracked it down to the `ListBox.ItemsSource<'T>` attribute definition.

It looks like the generic type is actually creating a new attribute definition on every single access instead of reusing the right definition; which in turn lead Fabulous to think we were unsetting the previous attribute to set a new one when actually it's the same value.

Fabulous would clear the ListBox items, which would trigger SelectedItemChanged to -1.

To fix it, I removed the generic typing of the ItemsSource attribute definition.
Like this the attribute definition stays stable.