### PR TITLE
Do not reuse TextBlock if widget switches between Text and Inlines to define the text

### DIFF
--- a/Fabulous.Avalonia.sln
+++ b/Fabulous.Avalonia.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 	ProjectSection(SolutionItems) = preProject
 					.gitignore = .gitignore
 		README.md = README.md
+		.github/workflows/build.yml = .github/workflows/build.yml
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabulous.Avalonia.Themes.Fluent", "src\Fabulous.Avalonia.Themes.Fluent\Fabulous.Avalonia.Themes.Fluent.fsproj", "{74A67DCD-5093-4CC6-B421-77376153C714}"

--- a/Fabulous.Avalonia.sln
+++ b/Fabulous.Avalonia.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -25,6 +25,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabulous.Avalonia.Themes.Fl
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Gallery", "samples\Gallery\Gallery.fsproj", "{AADAEC1A-44A7-401C-8B5E-F5506A1AA5AB}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabulous.Avalonia.Tests", "src\Fabulous.Avalonia.Tests\Fabulous.Avalonia.Tests.fsproj", "{ACA3C16C-4537-479A-B420-0718B2A2BF0B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,11 +52,16 @@ Global
 		{AADAEC1A-44A7-401C-8B5E-F5506A1AA5AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AADAEC1A-44A7-401C-8B5E-F5506A1AA5AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AADAEC1A-44A7-401C-8B5E-F5506A1AA5AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACA3C16C-4537-479A-B420-0718B2A2BF0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACA3C16C-4537-479A-B420-0718B2A2BF0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACA3C16C-4537-479A-B420-0718B2A2BF0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACA3C16C-4537-479A-B420-0718B2A2BF0B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{9EB9291D-09F8-43DD-9A95-154D4E6BA78E} = {60AC1554-2FB2-4AED-90F5-A4F99F7DDF5E}
 		{3CABE580-CB56-4853-926E-411BECD2BAB9} = {8D513303-98F9-40AA-AFA7-D92D920F96DF}
 		{74A67DCD-5093-4CC6-B421-77376153C714} = {60AC1554-2FB2-4AED-90F5-A4F99F7DDF5E}
 		{AADAEC1A-44A7-401C-8B5E-F5506A1AA5AB} = {8D513303-98F9-40AA-AFA7-D92D920F96DF}
+		{ACA3C16C-4537-479A-B420-0718B2A2BF0B} = {60AC1554-2FB2-4AED-90F5-A4F99F7DDF5E}
 	EndGlobalSection
 EndGlobal

--- a/samples/Gallery/App.fs
+++ b/samples/Gallery/App.fs
@@ -1,5 +1,6 @@
 namespace Gallery
 
+open System.Diagnostics
 open Avalonia
 open Avalonia.Controls
 open Avalonia.Layout
@@ -110,4 +111,9 @@ module App =
     let app model = DesktopApplication(Window(view model))
 #endif
 
-    let program = Program.statefulWithCmd init update app
+    let program =
+        Program.statefulWithCmd init update app
+#if DEBUG
+        |> Program.withLogger { ViewHelpers.defaultLogger() with MinLogLevel = LogLevel.Debug }
+        |> Program.withTrace (fun (format, args) -> Debug.WriteLine(format, box args))
+#endif

--- a/samples/Gallery/App.fs
+++ b/samples/Gallery/App.fs
@@ -114,6 +114,6 @@ module App =
     let program =
         Program.statefulWithCmd init update app
 #if DEBUG
-        |> Program.withLogger { ViewHelpers.defaultLogger() with MinLogLevel = LogLevel.Debug }
+        |> Program.withLogger { ViewHelpers.defaultLogger () with MinLogLevel = LogLevel.Debug }
         |> Program.withTrace (fun (format, args) -> Debug.WriteLine(format, box args))
 #endif

--- a/src/Fabulous.Avalonia.Tests/Fabulous.Avalonia.Tests.fsproj
+++ b/src/Fabulous.Avalonia.Tests/Fabulous.Avalonia.Tests.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Library.fs"/>
+    </ItemGroup>
+
+</Project>

--- a/src/Fabulous.Avalonia.Tests/Fabulous.Avalonia.Tests.fsproj
+++ b/src/Fabulous.Avalonia.Tests/Fabulous.Avalonia.Tests.fsproj
@@ -2,11 +2,24 @@
 
     <PropertyGroup>
         <TargetFramework>net7.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Library.fs"/>
+        <Compile Include="ViewHelperTests.fs" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="FsCheck.NUnit" Version="2.16.5" />
+        <PackageReference Include="FsUnit" Version="5.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="FSharp.Core" Version="7.0.0" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\Fabulous.Avalonia\Fabulous.Avalonia.fsproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Fabulous.Avalonia.Tests/Fabulous.Avalonia.Tests.fsproj
+++ b/src/Fabulous.Avalonia.Tests/Fabulous.Avalonia.Tests.fsproj
@@ -6,6 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Setup.fs" />
+        <Compile Include="Generators.fs" />
         <Compile Include="ViewHelperTests.fs" />
     </ItemGroup>
     

--- a/src/Fabulous.Avalonia.Tests/Generators.fs
+++ b/src/Fabulous.Avalonia.Tests/Generators.fs
@@ -1,0 +1,9 @@
+namespace Fabulous.Avalonia.Tests
+
+open FsCheck
+
+module Generators =
+    let nonNullString =
+        Arb.generate<string>
+        |> Gen.where (fun v -> v <> null)
+

--- a/src/Fabulous.Avalonia.Tests/Generators.fs
+++ b/src/Fabulous.Avalonia.Tests/Generators.fs
@@ -3,7 +3,4 @@ namespace Fabulous.Avalonia.Tests
 open FsCheck
 
 module Generators =
-    let nonNullString =
-        Arb.generate<string>
-        |> Gen.where (fun v -> v <> null)
-
+    let nonNullString = Arb.generate<string> |> Gen.where (fun v -> v <> null)

--- a/src/Fabulous.Avalonia.Tests/Library.fs
+++ b/src/Fabulous.Avalonia.Tests/Library.fs
@@ -1,5 +1,0 @@
-﻿namespace Fabulous.Avalonia.Tests
-
-module Say =
-    let hello name =
-        printfn "Hello %s" name

--- a/src/Fabulous.Avalonia.Tests/Library.fs
+++ b/src/Fabulous.Avalonia.Tests/Library.fs
@@ -1,0 +1,5 @@
+﻿namespace Fabulous.Avalonia.Tests
+
+module Say =
+    let hello name =
+        printfn "Hello %s" name

--- a/src/Fabulous.Avalonia.Tests/Setup.fs
+++ b/src/Fabulous.Avalonia.Tests/Setup.fs
@@ -7,7 +7,7 @@ open NUnit.Framework
 [<SetUpFixture>]
 type Setup() =
     static member RegisteredWidgets = ResizeArray<WidgetKey>()
-    
+
     [<OneTimeSetUp>]
     member this.Setup() =
         // Force the widgets to register before the tests start

--- a/src/Fabulous.Avalonia.Tests/Setup.fs
+++ b/src/Fabulous.Avalonia.Tests/Setup.fs
@@ -1,0 +1,14 @@
+namespace Fabulous.Avalonia.Tests
+
+open Fabulous
+open Fabulous.Avalonia
+open NUnit.Framework
+
+[<SetUpFixture>]
+type Setup() =
+    static member RegisteredWidgets = ResizeArray<WidgetKey>()
+    
+    [<OneTimeSetUp>]
+    member this.Setup() =
+        // Force the widgets to register before the tests start
+        Setup.RegisteredWidgets.Add(TextBlock.WidgetKey)

--- a/src/Fabulous.Avalonia.Tests/ViewHelperTests.fs
+++ b/src/Fabulous.Avalonia.Tests/ViewHelperTests.fs
@@ -1,0 +1,118 @@
+﻿namespace Fabulous.Avalonia.Tests
+
+open Fabulous
+open FsCheck
+open NUnit.Framework
+open FsUnit
+open FsCheck.NUnit
+open Fabulous.Avalonia
+
+module Generators =
+    // This is a hack to know how many widgets are currently registered
+    // Fabulous needs to expose all the registered widget definitions
+    let lastKey = WidgetDefinitionStore.getNextKey()
+    
+    let widgetKey =
+        Arb.generate<int>
+        |> Gen.where (fun v -> v > 0 && v < lastKey)
+        
+    let nonNullString =
+        Arb.generate<string>
+        |> Gen.where (fun v -> v <> null)
+
+[<TestFixture>]
+type ViewHelpers() =
+    [<Property>]
+    member _.``Existing Avalonia control can be reused if previous and current widgets are of the same type``() =
+        let arb = Arb.fromGen Generators.widgetKey
+        
+        Prop.forAll arb (fun widgetKey ->
+            let prev: Widget =
+                { Key = widgetKey
+                  DebugName = $"Widget-{widgetKey}"
+                  ScalarAttributes = ValueNone
+                  WidgetAttributes = ValueNone
+                  WidgetCollectionAttributes = ValueNone }
+                
+            let curr: Widget =
+                { Key = widgetKey
+                  DebugName = $"Widget-{widgetKey}"
+                  ScalarAttributes = ValueNone
+                  WidgetAttributes = ValueNone
+                  WidgetCollectionAttributes = ValueNone }
+            
+            let actual = ViewHelpers.canReuseView prev curr
+            
+            actual |> should equal true
+        )
+        
+    [<Property>]
+    member _.``Existing TextBlock control can not be reused if previous widget uses Text and current widget uses Inlines``() =
+        let arb = Arb.fromGen Generators.nonNullString
+        
+        Prop.forAll arb (fun text ->
+            let prev =
+                { Key = TextBlock.WidgetKey
+                  DebugName = "TextBlock"
+                  ScalarAttributes =
+                      ValueSome [|
+                          { Key = TextBlock.Text.Key
+                            DebugName = TextBlock.Text.Name
+                            Value = text
+                            NumericValue = 0uL }
+                      |]
+                  WidgetAttributes = ValueNone
+                  WidgetCollectionAttributes = ValueNone }
+                
+            let curr =
+                { Key = TextBlock.WidgetKey
+                  DebugName = "TextBlock"
+                  ScalarAttributes = ValueNone
+                  WidgetAttributes = ValueNone
+                  WidgetCollectionAttributes =
+                      ValueSome [|
+                          { Key = TextBlock.Inlines.Key
+                            DebugName = TextBlock.Inlines.Name
+                            Value = ArraySlice.emptyWithNull () }
+                      |] }
+            
+            let actual = ViewHelpers.canReuseView prev curr
+            
+            actual |> should equal false
+        )
+        
+    [<Property>]
+    member _.``Existing TextBlock control can not be reused if previous widget uses Inlines and current widget uses Text``() =
+        let arb = Arb.fromGen Generators.nonNullString
+        
+        Prop.forAll arb (fun text ->
+            let prev =
+                { Key = TextBlock.WidgetKey
+                  DebugName = "TextBlock"
+                  ScalarAttributes = ValueNone
+                  WidgetAttributes = ValueNone
+                  WidgetCollectionAttributes =
+                      ValueSome [|
+                          { Key = TextBlock.Inlines.Key
+                            DebugName = TextBlock.Inlines.Name
+                            Value = ArraySlice.emptyWithNull () }
+                      |] }
+                
+            let curr =
+                { Key = TextBlock.WidgetKey
+                  DebugName = "TextBlock"
+                  ScalarAttributes =
+                      ValueSome [|
+                          { Key = TextBlock.Text.Key
+                            DebugName = TextBlock.Text.Name
+                            Value = text
+                            NumericValue = 0uL }
+                      |]
+                  WidgetAttributes = ValueNone
+                  WidgetCollectionAttributes = ValueNone }
+            
+            let actual = ViewHelpers.canReuseView prev curr
+            
+            actual |> should equal false
+        )
+        

--- a/src/Fabulous.Avalonia.Tests/ViewHelperTests.fs
+++ b/src/Fabulous.Avalonia.Tests/ViewHelperTests.fs
@@ -13,64 +13,65 @@ type ViewHelpers() =
     member _.``Existing Avalonia control can be reused if previous and current widgets are of the same type``() =
         for widgetKey in Setup.RegisteredWidgets do
             let def = WidgetDefinitionStore.get widgetKey
-            
+
             let prev: Widget =
                 { Key = widgetKey
                   DebugName = def.Name
                   ScalarAttributes = ValueNone
                   WidgetAttributes = ValueNone
                   WidgetCollectionAttributes = ValueNone }
-                
+
             let curr: Widget =
                 { Key = widgetKey
                   DebugName = def.Name
                   ScalarAttributes = ValueNone
                   WidgetAttributes = ValueNone
                   WidgetCollectionAttributes = ValueNone }
-            
+
             let actual = ViewHelpers.canReuseView prev curr
-            
+
             actual |> should equal true
-        
+
     [<Property>]
-    member _.``Existing TextBlock control can not be reused if previous widget uses Text and current widget uses Inlines``() =
+    member _.``Existing TextBlock control can not be reused if previous widget uses Text and current widget uses Inlines``
+        ()
+        =
         let arb = Arb.fromGen Generators.nonNullString
-        
+
         Prop.forAll arb (fun text ->
             let prev =
                 { Key = TextBlock.WidgetKey
                   DebugName = "TextBlock"
                   ScalarAttributes =
-                      ValueSome [|
-                          { Key = TextBlock.Text.Key
-                            DebugName = TextBlock.Text.Name
-                            Value = text
-                            NumericValue = 0uL }
-                      |]
+                    ValueSome
+                        [| { Key = TextBlock.Text.Key
+                             DebugName = TextBlock.Text.Name
+                             Value = text
+                             NumericValue = 0uL } |]
                   WidgetAttributes = ValueNone
                   WidgetCollectionAttributes = ValueNone }
-                
+
             let curr =
                 { Key = TextBlock.WidgetKey
                   DebugName = "TextBlock"
                   ScalarAttributes = ValueNone
                   WidgetAttributes = ValueNone
                   WidgetCollectionAttributes =
-                      ValueSome [|
-                          { Key = TextBlock.Inlines.Key
-                            DebugName = TextBlock.Inlines.Name
-                            Value = ArraySlice.emptyWithNull () }
-                      |] }
-            
+                    ValueSome
+                        [| { Key = TextBlock.Inlines.Key
+                             DebugName = TextBlock.Inlines.Name
+                             Value = ArraySlice.emptyWithNull () } |] }
+
             let actual = ViewHelpers.canReuseView prev curr
-            
-            actual |> should equal false
-        )
-        
+
+            actual |> should equal false)
+
     [<Property>]
-    member _.``Existing TextBlock control can not be reused if previous widget uses Inlines and current widget uses Text``() =
+    member _.``Existing TextBlock control can not be reused if previous widget uses Inlines and current widget uses Text``
+        ()
+        =
         let arb = Arb.fromGen Generators.nonNullString
-        
+
         Prop.forAll arb (fun text ->
             let prev =
                 { Key = TextBlock.WidgetKey
@@ -78,27 +79,23 @@ type ViewHelpers() =
                   ScalarAttributes = ValueNone
                   WidgetAttributes = ValueNone
                   WidgetCollectionAttributes =
-                      ValueSome [|
-                          { Key = TextBlock.Inlines.Key
-                            DebugName = TextBlock.Inlines.Name
-                            Value = ArraySlice.emptyWithNull () }
-                      |] }
-                
+                    ValueSome
+                        [| { Key = TextBlock.Inlines.Key
+                             DebugName = TextBlock.Inlines.Name
+                             Value = ArraySlice.emptyWithNull () } |] }
+
             let curr =
                 { Key = TextBlock.WidgetKey
                   DebugName = "TextBlock"
                   ScalarAttributes =
-                      ValueSome [|
-                          { Key = TextBlock.Text.Key
-                            DebugName = TextBlock.Text.Name
-                            Value = text
-                            NumericValue = 0uL }
-                      |]
+                    ValueSome
+                        [| { Key = TextBlock.Text.Key
+                             DebugName = TextBlock.Text.Name
+                             Value = text
+                             NumericValue = 0uL } |]
                   WidgetAttributes = ValueNone
                   WidgetCollectionAttributes = ValueNone }
-            
+
             let actual = ViewHelpers.canReuseView prev curr
-            
-            actual |> should equal false
-        )
-        
+
+            actual |> should equal false)

--- a/src/Fabulous.Avalonia/Program.fs
+++ b/src/Fabulous.Avalonia/Program.fs
@@ -31,7 +31,7 @@ module ViewHelpers =
     let rec canReuseView (prev: Widget) (curr: Widget) =
         if ViewHelpers.canReuseView prev curr then
             let def = WidgetDefinitionStore.get curr.Key
-            
+
             // TargetType can be null for MemoWidget
             // but it has already been checked by Fabulous.ViewHelpers.canReuseView
             if def.TargetType <> null then
@@ -43,7 +43,7 @@ module ViewHelpers =
                 true
         else
             false
-            
+
     /// TextBlock's text can be defined by both the Text and Inlines property
     /// Except when switching between the two, Avalonia will automatically clear out the other property
     /// Depending on the order of execution, this can lead to a desync between Avalonia and Fabulous
@@ -52,11 +52,11 @@ module ViewHelpers =
         let switchingFromTextToInlines =
             (tryGetScalarValue prev TextBlock.Text).IsSome
             && (tryGetWidgetCollectionValue curr TextBlock.Inlines).IsSome
-            
+
         let switchingFromInlinesToText =
             (tryGetWidgetCollectionValue prev TextBlock.Inlines).IsSome
             && (tryGetScalarValue curr TextBlock.Text).IsSome
-            
+
         not switchingFromTextToInlines && not switchingFromInlinesToText
 
     let defaultLogger () =

--- a/src/Fabulous.Avalonia/Program.fs
+++ b/src/Fabulous.Avalonia/Program.fs
@@ -3,6 +3,7 @@ namespace Fabulous.Avalonia
 open System
 open System.Diagnostics
 open Avalonia
+open Avalonia.Controls
 open Avalonia.Threading
 
 open Fabulous
@@ -28,7 +29,35 @@ module ViewHelpers =
 
     /// Extend the canReuseView function to check Xamarin.Forms specific constraints
     let rec canReuseView (prev: Widget) (curr: Widget) =
-        if ViewHelpers.canReuseView prev curr then true else false
+        if ViewHelpers.canReuseView prev curr then
+            let def = WidgetDefinitionStore.get curr.Key
+            
+            // TargetType can be null for MemoWidget
+            // but it has already been checked by Fabulous.ViewHelpers.canReuseView
+            if def.TargetType <> null then
+                if def.TargetType.IsAssignableFrom(typeof<TextBlock>) then
+                    canReuseTextBlock prev curr
+                else
+                    true
+            else
+                true
+        else
+            false
+            
+    /// TextBlock's text can be defined by both the Text and Inlines property
+    /// Except when switching between the two, Avalonia will automatically clear out the other property
+    /// Depending on the order of execution, this can lead to a desync between Avalonia and Fabulous
+    /// So, it's better to not reuse a TextBlock when we are about to switch between Text and Inlines
+    and canReuseTextBlock (prev: Widget) (curr: Widget) =
+        let switchingFromTextToInlines =
+            (tryGetScalarValue prev TextBlock.Text).IsSome
+            && (tryGetWidgetCollectionValue curr TextBlock.Inlines).IsSome
+            
+        let switchingFromInlinesToText =
+            (tryGetWidgetCollectionValue prev TextBlock.Inlines).IsSome
+            && (tryGetScalarValue curr TextBlock.Text).IsSome
+            
+        not switchingFromTextToInlines && not switchingFromInlinesToText
 
     let defaultLogger () =
         let log (level, message) =


### PR DESCRIPTION
Fixes #58 

When switching from Text to Inlines, Fabulous will create all the inlines before setting Text to an empty string. Unfortunately when setting any Text value, Avalonia will clear our the freshly created inlines making Fabulous go out of sync which later will result in a crash.

To avoid this, we don't reuse TextBlocks when switching from Text to Inlines, or Inlines to Text.