### PR TITLE
Apply template for ListBox ItemsSource

### DIFF
--- a/samples/Gallery/App.fs
+++ b/samples/Gallery/App.fs
@@ -74,7 +74,7 @@ module App =
 
                 Button("Overview", ShowOverview)
 
-                (ListBox (model.Controls) (fun x -> ListBoxItem(TextBlock(x))))
+                (ListBox model.Controls)
                     .selectionMode(SelectionMode.Multiple)
                     .onSelectedIndexChanged (model.SelectedIndex, ItemSelected)
             })

--- a/samples/Gallery/App.fs
+++ b/samples/Gallery/App.fs
@@ -74,9 +74,7 @@ module App =
 
                 Button("Overview", ShowOverview)
 
-                ListBox(model.Controls, fun x ->
-                    TextBlock(x)
-                )
+                ListBox(model.Controls, (fun x -> TextBlock(x)))
                     .selectionMode(SelectionMode.Multiple)
                     .onSelectedIndexChanged (model.SelectedIndex, ItemSelected)
             })

--- a/samples/Gallery/App.fs
+++ b/samples/Gallery/App.fs
@@ -74,7 +74,9 @@ module App =
 
                 Button("Overview", ShowOverview)
 
-                (ListBox model.Controls)
+                ListBox(model.Controls, fun x ->
+                    TextBlock(x)
+                )
                     .selectionMode(SelectionMode.Multiple)
                     .onSelectedIndexChanged (model.SelectedIndex, ItemSelected)
             })

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="Widgets\MenuFlyout.fs" />
     <Compile Include="Widgets\ContextMenu.fs" />
     <Compile Include="Widgets\Menu.fs" />
+    <Compile Include="Widgets\ListBox.fs" />
     <Compile Include="Widgets\ComboBox.fs" />
     <Compile Include="Widgets\CheckBox.fs" />
     <Compile Include="Widgets\SplitView.fs" />

--- a/samples/Gallery/WidgetPage.fs
+++ b/samples/Gallery/WidgetPage.fs
@@ -47,6 +47,7 @@ module WidgetPage =
           CalendarDatePicker.sample
           SplitView.sample
           CheckBox.sample
+          ListBox.sample
           ComboBox.sample
           MenuFlyout.sample
           ContextMenu.sample

--- a/samples/Gallery/Widgets/ListBox.fs
+++ b/samples/Gallery/Widgets/ListBox.fs
@@ -70,7 +70,7 @@ module ListBox =
 
                 ListBoxItem(TextBlock("TextBlock"))
             }
-                
+
             TextBlock("ListBox with 1.000 items with recycling")
                 .fontWeight (FontWeight.Bold)
 

--- a/samples/Gallery/Widgets/ListBox.fs
+++ b/samples/Gallery/Widgets/ListBox.fs
@@ -47,32 +47,17 @@ module ListBox =
     let view model =
         VStack(spacing = 15.) {
 
-            TextBlock("ListBox using a collection with a string template")
+            TextBlock("ListBox using a collection with a WidgetDataTemplate")
                 .fontWeight (FontWeight.Bold)
 
-            ListBox(model.SampleData, fun x -> TextBlock($"{x.Name} ({x.Species})"))
+            ListBox(model.SampleData, (fun x -> TextBlock($"{x.Name} ({x.Species})")))
                 .onSelectedIndexChanged (model.SelectedIndex, SelectedIndexChanged)
-                
-            TextBlock("ListBox with 10.000 items with recycling")
-                .fontWeight (FontWeight.Bold)
-
-            ListBox(Seq.init 10000 id, fun x -> TextBlock($"Row {x}"))
-                .onSelectedIndexChanged (model.SelectedIndex, SelectedIndexChanged)
-
-            TextBlock(model.Notification)
-
-            //TextBlock("ListBox using a ListBoxItem template [INCOMPLETE]")
-            //  .fontWeight(FontWeight.Bold)
-            //  .margin (0,30,0,0)
-
-            //ListBox(model.SampleData, (fun x -> ListBoxItem(TextBlock(x.Name))))
-            //  .onSelectionChanged (SelectionChanged)
 
             TextBlock("ListBox using explicit ListBoxItem controls")
                 .fontWeight(FontWeight.Bold)
                 .margin (0, 30, 0, 0)
 
-            (ListBox() {
+            ListBox() {
                 ListBoxItem(
                     HStack(30.) {
                         TextBlock("Stack Item1")
@@ -81,17 +66,15 @@ module ListBox =
                     }
                 )
 
-                ListBoxItem(
-                    Ellipse()
-                        .size(50., 50.)
-                        .fill(SolidColorBrush(Colors.Yellow))
-                )
+                ListBoxItem(Ellipse().size(50., 50.).fill (SolidColorBrush(Colors.Yellow)))
 
-                ListBoxItem(
-                    TextBlock("TextBlock")
-                )
-            })
-                .selectedIndex (0)
+                ListBoxItem(TextBlock("TextBlock"))
+            }
+                
+            TextBlock("ListBox with 1.000 items with recycling")
+                .fontWeight (FontWeight.Bold)
+
+            ListBox(Seq.init 1000 id, (fun x -> TextBlock($"Row {x}")))
         }
 
     let sample =

--- a/samples/Gallery/Widgets/ListBox.fs
+++ b/samples/Gallery/Widgets/ListBox.fs
@@ -50,7 +50,13 @@ module ListBox =
             TextBlock("ListBox using a collection with a string template")
                 .fontWeight (FontWeight.Bold)
 
-            ListBox(model.SampleData, (fun x -> $"{x.Name} ({x.Species})"))
+            ListBox(model.SampleData, fun x -> TextBlock($"{x.Name} ({x.Species})"))
+                .onSelectedIndexChanged (model.SelectedIndex, SelectedIndexChanged)
+                
+            TextBlock("ListBox with 10.000 items with recycling")
+                .fontWeight (FontWeight.Bold)
+
+            ListBox(Seq.init 10000 id, fun x -> TextBlock($"Row {x}"))
                 .onSelectedIndexChanged (model.SelectedIndex, SelectedIndexChanged)
 
             TextBlock(model.Notification)
@@ -62,7 +68,7 @@ module ListBox =
             //ListBox(model.SampleData, (fun x -> ListBoxItem(TextBlock(x.Name))))
             //  .onSelectionChanged (SelectionChanged)
 
-            TextBlock("ListBox using explict ListBoxItem controls")
+            TextBlock("ListBox using explicit ListBoxItem controls")
                 .fontWeight(FontWeight.Bold)
                 .margin (0, 30, 0, 0)
 
@@ -75,9 +81,15 @@ module ListBox =
                     }
                 )
 
-                ListBoxItem(Ellipse().size(50., 50.).fill (SolidColorBrush(Colors.Yellow)))
+                ListBoxItem(
+                    Ellipse()
+                        .size(50., 50.)
+                        .fill(SolidColorBrush(Colors.Yellow))
+                )
 
-                ListBoxItem(TextBlock("TextBlock"))
+                ListBoxItem(
+                    TextBlock("TextBlock")
+                )
             })
                 .selectedIndex (0)
         }

--- a/samples/Gallery/Widgets/ListBox.fs
+++ b/samples/Gallery/Widgets/ListBox.fs
@@ -1,0 +1,88 @@
+namespace Gallery
+
+open Avalonia.Controls
+open Avalonia.Media
+open Fabulous.Avalonia
+
+open type Fabulous.Avalonia.View
+
+module ListBox =
+
+    type DataType =
+        { Name: string
+          Species: string
+          Family: string }
+
+    type Model =
+        { SampleData: DataType list
+          SelectedIndex: int
+          Notification: string }
+
+    type Msg =
+        | SelectedIndexChanged of int
+        | SelectionChanged of SelectionChangedEventArgs
+
+    let init () =
+        { SampleData =
+            [ { Name = "Dog"
+                Species = "Canis familiaris"
+                Family = "Canidae" }
+              { Name = "Cat"
+                Species = "Felis catus"
+                Family = "Felidae" }
+              { Name = "Mouse"
+                Species = "Mus musculus"
+                Family = "Muridae" } ]
+          SelectedIndex = -1
+          Notification = "" }
+
+    let update msg model =
+        match msg with
+        | SelectedIndexChanged index ->
+            { model with
+                SelectedIndex = index
+                Notification = $"Family: {model.SampleData[index].Family}" }
+        | SelectionChanged args -> { model with Notification = $"Selection: %A{args.AddedItems}" }
+
+    let view model =
+        VStack(spacing = 15.) {
+
+            TextBlock("ListBox using a collection with a string template")
+                .fontWeight (FontWeight.Bold)
+
+            ListBox(model.SampleData, (fun x -> $"{x.Name} ({x.Species})"))
+                .onSelectedIndexChanged (model.SelectedIndex, SelectedIndexChanged)
+
+            TextBlock(model.Notification)
+
+            //TextBlock("ListBox using a ListBoxItem template [INCOMPLETE]")
+            //  .fontWeight(FontWeight.Bold)
+            //  .margin (0,30,0,0)
+
+            //ListBox(model.SampleData, (fun x -> ListBoxItem(TextBlock(x.Name))))
+            //  .onSelectionChanged (SelectionChanged)
+
+            TextBlock("ListBox using explict ListBoxItem controls")
+                .fontWeight(FontWeight.Bold)
+                .margin (0, 30, 0, 0)
+
+            (ListBox() {
+                ListBoxItem(
+                    HStack(30.) {
+                        TextBlock("Stack Item1")
+                        TextBlock("Stack Item2")
+                        TextBlock("Stack Item3")
+                    }
+                )
+
+                ListBoxItem(Ellipse().size(50., 50.).fill (SolidColorBrush(Colors.Yellow)))
+
+                ListBoxItem(TextBlock("TextBlock"))
+            })
+                .selectedIndex (0)
+        }
+
+    let sample =
+        { Name = "ListBox"
+          Description = "A list box control"
+          Program = Helper.createProgram init update view }

--- a/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
+++ b/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Compile Include="ViewNode.fs" />
     <Compile Include="Attributes.fs" />
+    <Compile Include="VirtualizedCollection.fs" />
     <Compile Include="Widgets.fs" />
     <Compile Include="Widgets\_RenderOptions.fs" />
     <Compile Include="Widgets\_Animatable.fs" />

--- a/src/Fabulous.Avalonia/VirtualizedCollection.fs
+++ b/src/Fabulous.Avalonia/VirtualizedCollection.fs
@@ -1,0 +1,40 @@
+namespace Fabulous.Avalonia
+
+open System
+open Avalonia.Controls
+open Fabulous
+
+type WidgetDataTemplate(node: IViewNode, templateFn: obj -> Widget) as this =
+    inherit
+        Avalonia.Controls.Templates.FuncDataTemplate(
+            typeof<obj>,
+            System.Func<obj, INameScope, IControl>(fun data n -> this.Build(data, n)),
+            supportsRecycling = true
+        )
+
+    member this.Recycle(newData: obj, prevWidget: Widget, rowNode: IViewNode) : Widget =
+        let currWidget = templateFn newData
+        Reconciler.update node.TreeContext.CanReuseView (ValueSome prevWidget) currWidget rowNode
+        currWidget
+
+    member this.Build(data: obj, _: INameScope) =
+        let widget = templateFn data
+        let definition = WidgetDefinitionStore.get widget.Key
+
+        let struct (rowNode, view) =
+            definition.CreateView(widget, node.TreeContext, ValueSome node)
+
+        let item = ListBoxItem()
+        item.Content <- (view :?> IControl)
+
+        let mutable prevWidget = widget
+
+        item.DataContextChanged.AddHandler(
+            EventHandler(fun sender args ->
+                let currWidget =
+                    this.Recycle((sender :?> IControl).DataContext, prevWidget, rowNode)
+
+                prevWidget <- currWidget)
+        )
+
+        item

--- a/src/Fabulous.Avalonia/Widgets.fs
+++ b/src/Fabulous.Avalonia/Widgets.fs
@@ -17,13 +17,9 @@ type IFabElement =
     interface
     end
 
-type ItemTemplate<'templateResult> =
+type WidgetItems =
     { OriginalItems: IEnumerable
-      Template: obj -> 'templateResult }
-
-type WidgetTemplate = ItemTemplate<Widget>
-
-type StringTemplate = ItemTemplate<string>
+      Template: obj -> Widget }
 
 module Widgets =
     let registerWithFactory<'T when 'T :> IAvaloniaObject> (factory: unit -> 'T) =
@@ -86,25 +82,9 @@ module WidgetHelpers =
         =
         AttributeCollectionBuilder<'msg, 'marker, 'item>(widget, collectionAttributeDefinition)
 
-    let buildItems<'msg, 'marker, 'itemData, 'templateResult>
+    let buildItems<'msg, 'marker, 'itemData, 'itemMarker>
         key
-        (attrDef: SimpleScalarAttributeDefinition<ItemTemplate<'templateResult>>)
-        (items: seq<'itemData>)
-        (itemTemplate: 'itemData -> 'templateResult)
-        =
-        let template (item: obj) =
-            let item = unbox<'itemData> item
-            itemTemplate item
-
-        let data: ItemTemplate<'templateResult> =
-            { OriginalItems = items
-              Template = template }
-
-        WidgetBuilder<'msg, 'marker>(key, attrDef.WithValue(data))
-
-    let buildWidgetItems<'msg, 'marker, 'itemData, 'itemMarker>
-        key
-        (attrDef: SimpleScalarAttributeDefinition<WidgetTemplate>)
+        (attrDef: SimpleScalarAttributeDefinition<WidgetItems>)
         (items: seq<'itemData>)
         (itemTemplate: 'itemData -> WidgetBuilder<'msg, 'itemMarker>)
         =
@@ -112,7 +92,7 @@ module WidgetHelpers =
             let item = unbox<'itemData> item
             (itemTemplate item).Compile()
 
-        let data: WidgetTemplate =
+        let data: WidgetItems =
             { OriginalItems = items
               Template = template }
 

--- a/src/Fabulous.Avalonia/Widgets/Controls/ListBox.fs
+++ b/src/Fabulous.Avalonia/Widgets/Controls/ListBox.fs
@@ -1,6 +1,5 @@
 namespace Fabulous.Avalonia
 
-open System
 open System.Collections.Generic
 open Avalonia.Controls
 open Fabulous
@@ -12,40 +11,10 @@ type IFabListBox =
 
 module ListBox =
     let WidgetKey = Widgets.register<ListBox> ()
-    
-    type WidgetDataTemplate(node: IViewNode, templateFn: obj -> Widget) as this =
-        inherit Avalonia.Controls.Templates.FuncDataTemplate(
-            typeof<obj>,
-            System.Func<obj, INameScope, IControl>(fun data n -> this.Build(data, n)),
-            supportsRecycling = true
-        )
-        
-        member this.Recycle(newData: obj, prevWidget: Widget, rowNode: IViewNode): Widget =
-            let currWidget = templateFn newData
-            Reconciler.update node.TreeContext.CanReuseView (ValueSome prevWidget) currWidget rowNode
-            currWidget
-        
-        member this.Build(data: obj, _: INameScope) =            
-            let widget = templateFn data
-            let definition = WidgetDefinitionStore.get widget.Key
-            let struct (rowNode, view) = definition.CreateView(widget, node.TreeContext, ValueSome node)
-            let item = ListBoxItem()
-            item.Content <- (view :?> IControl)
-            
-            let mutable prevWidget = widget
-            
-            item.DataContextChanged.AddHandler(
-                EventHandler(fun sender args ->
-                    let currWidget = this.Recycle((sender :?> IControl).DataContext, prevWidget, rowNode)
-                    prevWidget <- currWidget
-                )
-            )
-            
-            item
 
     let Items =
         Attributes.defineListWidgetCollection "ListBox_Items" (fun target -> (target :?> ListBox).Items :?> IList<_>)
-        
+
     let ItemsSource =
         Attributes.defineSimpleScalar<WidgetItems>
             "ListBox_ItemsSource"
@@ -58,7 +27,9 @@ module ListBox =
                     itemsView.ClearValue(ListBox.ItemTemplateProperty)
                     itemsView.ClearValue(ListBox.ItemsProperty)
                 | ValueSome value ->
-                    itemsView.SetValue(ListBox.ItemTemplateProperty, WidgetDataTemplate(node, unbox >> value.Template)) |> ignore
+                    itemsView.SetValue(ListBox.ItemTemplateProperty, WidgetDataTemplate(node, unbox >> value.Template))
+                    |> ignore
+
                     itemsView.SetValue(ListBox.ItemsProperty, value.OriginalItems))
 
     let SelectionMode =
@@ -92,12 +63,9 @@ module ListBoxBuilders =
                 ListBox.ItemsSource
                 items
                 template
-                
+
         static member inline ListBox<'msg>() =
-            CollectionBuilder<'msg, IFabListBox, IFabListBoxItem>(
-                ListBox.WidgetKey,
-                ListBox.Items
-            )
+            CollectionBuilder<'msg, IFabListBox, IFabListBoxItem>(ListBox.WidgetKey, ListBox.Items)
 
 [<Extension>]
 type ListBoxModifiers =


### PR DESCRIPTION
The template function was not being applied to ListBox ItemSource, so it was only rendering correctly if the ItemSource was a collection of item display strings (for any other item type, the ListBox would render the internal string representation of the object rather than the conversion defined by the template function).

In this commit, the ListBox  correctly displays items for templates functions with a string output (perhaps the most common use case?).

However, it does not presently work for a template function with a ListBoxItem output. I've left some commented out code in Controls/ListBox.fs to demonstrate the present limitation. This template renders an internal string representation of the compiled ListBoxItem widget rather than the widget itself. I suspect for a ListBoxItem template to work with ItemSource, we will first need to implement the ItemTemplate property in the parent ItemContol class, but perhaps there is some other way using the exiting the widget helpers that I have overlooked.

- Add string template support to the ListBox ItemsSource
- Add CollectionBuilder constructor and Yield to ListBox, so that ListBoxItem children can be directly added (similar to ComboBox)
- Add ListBox Sample to Gallery