### PR TITLE
Remove rollback flag from dotnet workload install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         dotnet-version: 7.0.x
     - name: Install dotnet workload
-      run: dotnet workload install android ios --from-rollback-file .github/workflows/WorkloadManifest.json
+      run: dotnet workload install android ios
     - name: Restore
       run: dotnet restore ${SLN_FILE}
     - name: Build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         dotnet-version: 7.0.x
     - name: Install dotnet workload
-      run: dotnet workload install android ios --from-rollback-file .github/workflows/WorkloadManifest.json
+      run: dotnet workload install android ios
     - name: Restore
       run: dotnet restore ${SLN_FILE}
     - name: Build


### PR DESCRIPTION
Microsoft just released dotnet 7.0.102 and they apparently decided to do a breaking change and prevent people from installing the `net-ios` and `net-android` workloads 7.0.49...

This PR removes the `--from-rollback-file` flag from the `dotnet workload install` step in the build CI. This will let `dotnet` installs the latest `net-ios` and `net-android` versions, hoping it will not crash 🤞