### PR TITLE
Add IBrush Escape Hatch

### DIFF
--- a/src/Fabulous.Avalonia/Views/Controls/Border.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Border.fs
@@ -77,7 +77,7 @@ type BorderModifiers =
         this.AddWidget(Border.BackgroundWidget.WithValue(value.Compile()))
 
     [<Extension>]
-    static member inline background(this: WidgetBuilder<'msg, #IFabBorder>, value: IBrush) =
+    static member inline background(this: WidgetBuilder<'msg, #IFabBorder>, value: #IBrush) =
         this.AddScalar(Border.Background.WithValue(value))
 
     [<Extension>]
@@ -89,7 +89,7 @@ type BorderModifiers =
         this.AddWidget(Border.BorderBrushWidget.WithValue(value.Compile()))
 
     [<Extension>]
-    static member inline borderBrush(this: WidgetBuilder<'msg, #IFabBorder>, brush: IBrush) =
+    static member inline borderBrush(this: WidgetBuilder<'msg, #IFabBorder>, brush: #IBrush) =
         this.AddScalar(Border.BorderBrush.WithValue(brush))
 
     [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/Calendar.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Calendar.fs
@@ -82,6 +82,10 @@ type CalendarModifiers =
         this.AddWidget(Calendar.HeaderBackgroundWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline headerBackground(this: WidgetBuilder<'msg, #IFabCalendar>, brush: #IBrush) =
+        this.AddScalar(Calendar.HeaderBackground.WithValue(brush))
+
+    [<Extension>]
     static member inline headerBackground(this: WidgetBuilder<'msg, #IFabCalendar>, brush: string) =
         this.AddScalar(Calendar.HeaderBackground.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/Controls/Documents/TextDecoration.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Documents/TextDecoration.fs
@@ -65,6 +65,10 @@ type TextDecorationModifiers =
         this.AddWidget(TextDecoration.StrokeWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline stroke(this: WidgetBuilder<'msg, #IFabTextDecoration>, brush: #IBrush) =
+        this.AddScalar(TextDecoration.Stroke.WithValue(brush))
+
+    [<Extension>]
     static member inline stroke(this: WidgetBuilder<'msg, #IFabTextDecoration>, brush: string) =
         this.AddScalar(TextDecoration.Stroke.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/Controls/Documents/_TextElement.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Documents/_TextElement.fs
@@ -44,6 +44,10 @@ type TextElementModifiers =
         this.AddWidget(TextElement.BackgroundWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline background(this: WidgetBuilder<'msg, #IFabTextElement>, brush: #IBrush) =
+        this.AddScalar(TextElement.Background.WithValue(brush))
+
+    [<Extension>]
     static member inline background(this: WidgetBuilder<'msg, #IFabTextElement>, brush: string) =
         this.AddScalar(TextElement.Background.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 
@@ -70,6 +74,10 @@ type TextElementModifiers =
     [<Extension>]
     static member inline foreground(this: WidgetBuilder<'msg, #IFabTextElement>, content: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(TextElement.ForegroundWidget.WithValue(content.Compile()))
+
+    [<Extension>]
+    static member inline foreground(this: WidgetBuilder<'msg, #IFabTextElement>, brush: #IBrush) =
+        this.AddScalar(TextElement.Foreground.WithValue(brush))
 
     [<Extension>]
     static member inline foreground(this: WidgetBuilder<'msg, #IFabTextElement>, brush: string) =

--- a/src/Fabulous.Avalonia/Views/Controls/SelectableTextBlock.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/SelectableTextBlock.fs
@@ -66,6 +66,10 @@ type SelectableTextBlockModifiers =
         this.AddWidget(SelectableTextBlock.SelectionBrushWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline selectionBrush(this: WidgetBuilder<'msg, #IFabSelectableTextBlock>, brush: #IBrush) =
+        this.AddScalar(SelectableTextBlock.SelectionBrush.WithValue(brush))
+
+    [<Extension>]
     static member inline selectionBrush(this: WidgetBuilder<'msg, #IFabSelectableTextBlock>, brush: string) =
         this.AddScalar(SelectableTextBlock.SelectionBrush.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/Controls/Shapes/_Shape.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Shapes/_Shape.fs
@@ -53,6 +53,10 @@ type ShapeModifiers =
         this.AddWidget(Shape.FillWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline fill(this: WidgetBuilder<'msg, #IFabShape>, brush: #IBrush) =
+        this.AddScalar(Shape.Fill.WithValue(brush))
+
+    [<Extension>]
     static member inline fill(this: WidgetBuilder<'msg, #IFabShape>, brush: string) =
         this.AddScalar(Shape.Fill.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 
@@ -63,6 +67,10 @@ type ShapeModifiers =
     [<Extension>]
     static member inline stroke(this: WidgetBuilder<'msg, #IFabShape>, content: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(Shape.StrokeWidget.WithValue(content.Compile()))
+
+    [<Extension>]
+    static member inline stroke(this: WidgetBuilder<'msg, #IFabShape>, brush: #IBrush) =
+        this.AddScalar(Shape.Stroke.WithValue(brush))
 
     [<Extension>]
     static member inline stroke(this: WidgetBuilder<'msg, #IFabShape>, brush: string) =

--- a/src/Fabulous.Avalonia/Views/Controls/TextBlock.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/TextBlock.fs
@@ -107,6 +107,10 @@ type TextBlockModifiers =
         this.AddWidget(TextBlock.BackgroundWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline background(this: WidgetBuilder<'msg, #IFabTextBlock>, brush: #IBrush) =
+        this.AddScalar(TextBlock.Background.WithValue(brush))
+
+    [<Extension>]
     static member inline background(this: WidgetBuilder<'msg, #IFabTextBlock>, brush: string) =
         this.AddScalar(TextBlock.Background.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 
@@ -137,6 +141,10 @@ type TextBlockModifiers =
     [<Extension>]
     static member inline foreground(this: WidgetBuilder<'msg, #IFabTextBlock>, content: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(TextBlock.ForegroundWidget.WithValue(content.Compile()))
+
+    [<Extension>]
+    static member inline foreground(this: WidgetBuilder<'msg, #IFabTextBlock>, brush: #IBrush) =
+        this.AddScalar(TextBlock.Foreground.WithValue(brush))
 
     [<Extension>]
     static member inline foreground(this: WidgetBuilder<'msg, #IFabTextBlock>, brush: string) =

--- a/src/Fabulous.Avalonia/Views/Controls/TextBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/TextBox.fs
@@ -217,6 +217,14 @@ type TextBoxModifiers =
         this.AddWidget(TextBox.CaretBrushWidget.WithValue(value.Compile()))
 
     [<Extension>]
+    static member inline caretBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: #IBrush) =
+        this.AddScalar(TextBox.CaretBrush.WithValue(brush))
+
+    [<Extension>]
+    static member inline caretBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: string) =
+        this.AddScalar(TextBox.CaretBrush.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
+
+    [<Extension>]
     static member inline innerLeftContent(this: WidgetBuilder<'msg, #IFabTextBox>, value: WidgetBuilder<'msg, #IFabControl>) =
         this.AddWidget(TextBox.InnerLeftContentWidget.WithValue(value.Compile()))
 
@@ -225,12 +233,12 @@ type TextBoxModifiers =
         this.AddWidget(TextBox.InnerRightContentWidget.WithValue(value.Compile()))
 
     [<Extension>]
-    static member inline caretBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: string) =
-        this.AddScalar(TextBox.CaretBrush.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
-
-    [<Extension>]
     static member inline selectionBrush(this: WidgetBuilder<'msg, #IFabTextBox>, value: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(TextBox.SelectionBrushWidget.WithValue(value.Compile()))
+
+    [<Extension>]
+    static member inline selectionBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: #IBrush) =
+        this.AddScalar(TextBox.SelectionBrush.WithValue(brush))
 
     [<Extension>]
     static member inline selectionBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: string) =
@@ -239,6 +247,10 @@ type TextBoxModifiers =
     [<Extension>]
     static member inline selectionForegroundBrush(this: WidgetBuilder<'msg, #IFabTextBox>, value: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(TextBox.SelectionForegroundBrushWidget.WithValue(value.Compile()))
+
+    [<Extension>]
+    static member inline selectionForegroundBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: #IBrush) =
+        this.AddScalar(TextBox.SelectionForegroundBrush.WithValue(brush))
 
     [<Extension>]
     static member inline selectionForegroundBrush(this: WidgetBuilder<'msg, #IFabTextBox>, brush: string) =

--- a/src/Fabulous.Avalonia/Views/Controls/TickBar.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/TickBar.fs
@@ -63,6 +63,10 @@ type TickBarModifiers =
         this.AddWidget(TickBar.FillWidget.WithValue(value.Compile()))
 
     [<Extension>]
+    static member inline fill(this: WidgetBuilder<'msg, #IFabTickBar>, brush: #IBrush) =
+        this.AddScalar(TickBar.Fill.WithValue(brush))
+
+    [<Extension>]
     static member inline fill(this: WidgetBuilder<'msg, #IFabTickBar>, brush: string) =
         this.AddScalar(TickBar.Fill.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/Layouts/SliptView.fs
+++ b/src/Fabulous.Avalonia/Views/Layouts/SliptView.fs
@@ -102,6 +102,10 @@ type SplitViewModifiers =
         this.AddWidget(SplitView.PaneBackgroundWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline paneBackground(this: WidgetBuilder<'msg, #IFabSplitView>, brush: #IBrush) =
+        this.AddScalar(SplitView.PaneBackground.WithValue(brush))
+
+    [<Extension>]
     static member inline paneBackground(this: WidgetBuilder<'msg, #IFabSplitView>, brush: string) =
         this.AddScalar(SplitView.PaneBackground.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/Media/Drawing/DrawingGroup.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Drawing/DrawingGroup.fs
@@ -51,6 +51,10 @@ type DrawingGroupModifiers =
         this.AddWidget(DrawingGroup.OpacityMaskWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline opacityMask(this: WidgetBuilder<'msg, #IFabDrawingGroup>, brush: #IBrush) =
+        this.AddScalar(DrawingGroup.OpacityMask.WithValue(brush))
+
+    [<Extension>]
     static member inline opacityMask(this: WidgetBuilder<'msg, #IFabDrawingGroup>, brush: string) =
         this.AddScalar(DrawingGroup.OpacityMask.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/Media/Drawing/GeometryDrawing.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Drawing/GeometryDrawing.fs
@@ -41,6 +41,16 @@ module GeometryDrawingBuilders =
                 )
             )
 
+        static member GeometryDrawing(geometry: string, pen: WidgetBuilder<'msg, #IFabPen>, brush: #IFabBrush) =
+            WidgetBuilder<'msg, IFabGeometryDrawing>(
+                GeometryDrawing.WidgetKey,
+                AttributesBundle(
+                    StackList.two(GeometryDrawing.Geometry.WithValue(StreamGeometry.Parse(geometry)), GeometryDrawing.Brush.WithValue(brush)),
+                    ValueSome [| GeometryDrawing.Pen.WithValue(pen.Compile()) |],
+                    ValueNone
+                )
+            )
+
         static member GeometryDrawing(geometry: string, pen: WidgetBuilder<'msg, #IFabPen>, brush: string) =
             WidgetBuilder<'msg, IFabGeometryDrawing>(
                 GeometryDrawing.WidgetKey,
@@ -67,6 +77,18 @@ module GeometryDrawingBuilders =
                     ValueSome
                         [| GeometryDrawing.GeometryWidget.WithValue(geometry.Compile())
                            GeometryDrawing.BrushWidget.WithValue(brush.Compile())
+                           GeometryDrawing.Pen.WithValue(pen.Compile()) |],
+                    ValueNone
+                )
+            )
+
+        static member GeometryDrawing(geometry: WidgetBuilder<'msg, #IFabGeometry>, pen: WidgetBuilder<'msg, #IFabPen>, brush: #IBrush) =
+            WidgetBuilder<'msg, IFabGeometryDrawing>(
+                GeometryDrawing.WidgetKey,
+                AttributesBundle(
+                    StackList.one(GeometryDrawing.Brush.WithValue(brush)),
+                    ValueSome
+                        [| GeometryDrawing.GeometryWidget.WithValue(geometry.Compile())
                            GeometryDrawing.Pen.WithValue(pen.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.Avalonia/Views/Media/Drawing/GlyphRunDrawing.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Drawing/GlyphRunDrawing.fs
@@ -34,6 +34,13 @@ module GlyphRunDrawingBuilders =
                 )
             )
 
+        static member GlyphRunDrawing(brush: #IBrush, glyphRun: GlyphRun) =
+            WidgetBuilder<'msg, IFabGlyphRunDrawing>(
+                GlyphRunDrawing.WidgetKey,
+                GlyphRunDrawing.GlyphRun.WithValue(glyphRun),
+                GlyphRunDrawing.Foreground.WithValue(brush)
+            )
+
         static member GlyphRunDrawing(brush: string, glyphRun: GlyphRun) =
             WidgetBuilder<'msg, IFabGlyphRunDrawing>(
                 GlyphRunDrawing.WidgetKey,

--- a/src/Fabulous.Avalonia/Views/Media/Pen.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Pen.fs
@@ -37,6 +37,9 @@ module PenBuilders =
                 AttributesBundle(StackList.one(Pen.Thickness.WithValue(thickness)), ValueSome [| Pen.BrushWidget.WithValue(brush.Compile()) |], ValueNone)
             )
 
+        static member Pen(brush: #IBrush, thickness: float) =
+            WidgetBuilder<'msg, IFabPen>(Pen.WidgetKey, Pen.Thickness.WithValue(thickness), Pen.Brush.WithValue(brush))
+
         static member Pen(brush: string, thickness: float) =
             WidgetBuilder<'msg, IFabPen>(
                 Pen.WidgetKey,

--- a/src/Fabulous.Avalonia/Views/Menu/ComboBox.fs
+++ b/src/Fabulous.Avalonia/Views/Menu/ComboBox.fs
@@ -64,7 +64,11 @@ type ComboBoxModifiers =
         this.AddWidget(ComboBox.PlaceholderForegroundWidget.WithValue(content.Compile()))
 
     [<Extension>]
-    static member inline background(this: WidgetBuilder<'msg, #IFabComboBox>, brush: string) =
+    static member inline placeholderForeground(this: WidgetBuilder<'msg, #IFabComboBox>, brush: #IBrush) =
+        this.AddScalar(ComboBox.PlaceholderForeground.WithValue(brush))
+
+    [<Extension>]
+    static member inline placeholderForeground(this: WidgetBuilder<'msg, #IFabComboBox>, brush: string) =
         this.AddScalar(ComboBox.PlaceholderForeground.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 
     [<Extension>]

--- a/src/Fabulous.Avalonia/Views/_Panel.fs
+++ b/src/Fabulous.Avalonia/Views/_Panel.fs
@@ -27,6 +27,10 @@ type PanelModifiers =
         this.AddWidget(Panel.BackgroundWidget.WithValue(brush.Compile()))
 
     [<Extension>]
+    static member inline background(this: WidgetBuilder<'msg, #IFabPanel>, brush: #IBrush) =
+        this.AddScalar(Panel.Background.WithValue(brush))
+
+    [<Extension>]
     static member inline background(this: WidgetBuilder<'msg, #IFabPanel>, brush: string) =
         this.AddScalar(Panel.Background.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/_TemplatedControl.fs
+++ b/src/Fabulous.Avalonia/Views/_TemplatedControl.fs
@@ -60,12 +60,20 @@ type TemplatedControlModifiers =
         this.AddWidget(TemplatedControl.BackgroundWidget.WithValue(value.Compile()))
 
     [<Extension>]
+    static member inline background(this: WidgetBuilder<'msg, #IFabTemplatedControl>, brush: #IBrush) =
+        this.AddScalar(TemplatedControl.Background.WithValue(brush))
+
+    [<Extension>]
     static member inline background(this: WidgetBuilder<'msg, #IFabTemplatedControl>, brush: string) =
         this.AddScalar(TemplatedControl.Background.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 
     [<Extension>]
     static member inline borderBrush(this: WidgetBuilder<'msg, #IFabTemplatedControl>, value: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(TemplatedControl.BorderBrushWidget.WithValue(value.Compile()))
+
+    [<Extension>]
+    static member inline borderBrush(this: WidgetBuilder<'msg, #IFabTemplatedControl>, brush: #IBrush) =
+        this.AddScalar(TemplatedControl.BorderBrush.WithValue(brush))
 
     [<Extension>]
     static member inline borderBrush(this: WidgetBuilder<'msg, #IFabTemplatedControl>, brush: string) =
@@ -102,6 +110,10 @@ type TemplatedControlModifiers =
     [<Extension>]
     static member inline foreground(this: WidgetBuilder<'msg, #IFabTemplatedControl>, value: WidgetBuilder<'msg, #IFabBrush>) =
         this.AddWidget(TemplatedControl.ForegroundWidget.WithValue(value.Compile()))
+
+    [<Extension>]
+    static member inline foreground(this: WidgetBuilder<'msg, #IFabTemplatedControl>, brush: #IBrush) =
+        this.AddScalar(TemplatedControl.Foreground.WithValue(brush))
 
     [<Extension>]
     static member inline foreground(this: WidgetBuilder<'msg, #IFabTemplatedControl>, brush: string) =

--- a/src/Fabulous.Avalonia/Views/_TopLevel.fs
+++ b/src/Fabulous.Avalonia/Views/_TopLevel.fs
@@ -56,6 +56,10 @@ type TopLevelModifiers =
         this.AddWidget(TopLevel.TransparencyBackgroundFallbackWidget.WithValue(content.Compile()))
 
     [<Extension>]
+    static member inline transparencyBackgroundFallback(this: WidgetBuilder<'msg, #IFabTopLevel>, brush: #IBrush) =
+        this.AddScalar(TopLevel.TransparencyBackgroundFallback.WithValue(brush))
+
+    [<Extension>]
     static member inline transparencyBackgroundFallback(this: WidgetBuilder<'msg, #IFabTopLevel>, brush: string) =
         this.AddScalar(TopLevel.TransparencyBackgroundFallback.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 

--- a/src/Fabulous.Avalonia/Views/_Visual.fs
+++ b/src/Fabulous.Avalonia/Views/_Visual.fs
@@ -70,6 +70,10 @@ type VisualModifiers =
         this.AddWidget(Visual.OpacityMaskWidget.WithValue(mask.Compile()))
 
     [<Extension>]
+    static member inline opacityMask(this: WidgetBuilder<'msg, #IFabVisual>, brush: #IBrush) =
+        this.AddScalar(Visual.OpacityMask.WithValue(brush))
+
+    [<Extension>]
     static member inline opacityMask(this: WidgetBuilder<'msg, #IFabVisual>, brush: string) =
         this.AddScalar(Visual.OpacityMask.WithValue(brush |> Color.Parse |> ImmutableSolidColorBrush))
 


### PR DESCRIPTION
We need to add an escape hatch to ensure that we can use transitions/ animation at the main widget level: 

- Using the `SolidColorBrush` widget does not work with transitions
```fsharp
Border()
       .style(borderTestStyle)
       .background(SolidColorBrush(Colors.Red)
       .onPointerEnter(OnPointerEnter)
       .onPointerExited(OnPointerExited)
       .transitions() {
           BrushTransition(Border.BackgroundProperty, TimeSpan.FromSeconds(0.5))
        }
```

But, if we use ` .background(Brushes. Red)` works as expected. So to allow this, we are allowing to use any `IBrush.`
