### PR TITLE
Exclude 'net7.0-ios' from build on Linux automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,7 @@ For a starter guide see our [Get Started with Fabulous.Avalonia](https://fabulou
 dotnet new install Fabulous.Avalonia.Templates
 dotnet new fabulous-avalonia -n MyApp
 ```
-If you are using Linux net7.0-android and net7.0-ios are not supported. So we need to remove them from the TargetFrameworks
-
-```fsharp
-<PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-</PropertyGroup>
-```
+net7.0-ios is not supported on Linux, thus net7.0-ios is excluded from build on a Linux host.
 
 ## Documentation
 

--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -3,7 +3,9 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">

--- a/samples/DrawingApp/DrawingApp.fsproj
+++ b/samples/DrawingApp/DrawingApp.fsproj
@@ -2,7 +2,9 @@
   <Import Project="..\..\src\Fabulous.Avalonia.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -3,7 +3,9 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/GameOfLife/GameOfLife.fsproj
+++ b/samples/GameOfLife/GameOfLife.fsproj
@@ -2,7 +2,9 @@
   <Import Project="..\..\src\Fabulous.Avalonia.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">

--- a/samples/TicTacToe/TicTacToe.fsproj
+++ b/samples/TicTacToe/TicTacToe.fsproj
@@ -3,7 +3,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
+++ b/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
@@ -1,6 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <!-- NuGet Package -->

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!--if you are on Linux net7.0-android;net7.0-ios are not supported. So we need to remove them from the TargetFrameworks-->
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
+    <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <AvaloniaPlatform>$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))</AvaloniaPlatform>


### PR DESCRIPTION
net7.0-ios is currently not available on Linux. Currently the project template user has to manually remove it on his local development machine. This PR automatically excludes net7.0-ios on Linux hosts during build time.