### PR TITLE
Revert to use Minimum Maximum as part of the constructor

### DIFF
--- a/samples/CounterApp/App.fs
+++ b/samples/CounterApp/App.fs
@@ -65,7 +65,7 @@ module App =
                 .margin(20.)
                 .centerHorizontal()
 
-            Slider(double model.Step, SetStep).minimum(0.).maximum(10.)
+            Slider(0., 10., float model.Step, SetStep)
 
             TextBlock($"Step size: %d{model.Step}").centerText()
 

--- a/samples/Gallery/Widgets/AcrylicPage.fs
+++ b/samples/Gallery/Widgets/AcrylicPage.fs
@@ -60,7 +60,7 @@ module AcrylicPage =
             .foreground(SolidColorBrush(Colors.Black))
 
     let sliderStyle (this: WidgetBuilder<'msg, IFabSlider>) =
-        this.margin(8., 0.).minimum(0.).maximum(1.).largeChange(0.2).smallChange(0.1)
+        this.margin(8., 0.).largeChange(0.2).smallChange(0.1)
 
     let view model =
         VStack(spacing = 20.) {
@@ -68,7 +68,7 @@ module AcrylicPage =
                 (Grid(coldefs = [ Auto; Star; Auto ], rowdefs = [ Auto; Auto ]) {
                     TextBlock("TintOpacity").gridRow(0).gridColumn(0).style(textBlockStyle)
 
-                    Slider(model.TintOpacitySlider, TintOpacitySliderValueChanged)
+                    Slider(0., 1., model.TintOpacitySlider, TintOpacitySliderValueChanged)
                         .gridRow(0)
                         .gridColumn(1)
                         .style(sliderStyle)
@@ -80,7 +80,7 @@ module AcrylicPage =
 
                     TextBlock("MaterialOpacity").gridRow(1).gridColumn(0).style(textBlockStyle)
 
-                    Slider(model.MaterialOpacitySlider, MaterialOpacitySliderValueChanged)
+                    Slider(0., 1., model.MaterialOpacitySlider, MaterialOpacitySliderValueChanged)
                         .gridRow(1)
                         .gridColumn(1)
                         .style(sliderStyle)

--- a/samples/Gallery/Widgets/AdornerLayer.fs
+++ b/samples/Gallery/Widgets/AdornerLayer.fs
@@ -43,11 +43,7 @@ module AdornerLayer =
             (Grid(coldefs = [ Auto; Star ], rowdefs = [ Auto ]) {
                 TextBlock("Rotation").gridColumn(0).gridRow(0)
 
-                Slider(model.Angle, ValueChanged)
-                    .gridColumn(1)
-                    .gridRow(0)
-                    .minimum(0.)
-                    .maximum(360.)
+                Slider(0., 360., model.Angle, ValueChanged).gridColumn(1).gridRow(0)
             })
                 .dock(Dock.Top)
 

--- a/samples/Gallery/Widgets/LayoutTransformControl.fs
+++ b/samples/Gallery/Widgets/LayoutTransformControl.fs
@@ -26,9 +26,7 @@ module LayoutTransformControl =
                     TextBlock($"{model.Angle}")
                 }
 
-                Slider(model.Angle, SliderValueChanged)
-                    .width(200.)
-                    .minimumMaximum(model.Min, model.Max)
+                Slider(model.Min, model.Max, model.Angle, SliderValueChanged).width(200.)
             })
                 .margin(16.)
                 .centerHorizontal()

--- a/samples/Gallery/Widgets/Slider.fs
+++ b/samples/Gallery/Widgets/Slider.fs
@@ -48,25 +48,19 @@ module Slider =
         | ValueChanged7 value -> { model with SliderValue7 = value }
 
     let sliderStyle (this: WidgetBuilder<'msg, IFabSlider>) =
-        this
-            .tickFrequency(10.)
-            .minimum(0.)
-            .maximum(100.)
-            .width(300.)
-            .largeChange(0.2)
-            .smallChange(0.1)
+        this.tickFrequency(10.).width(300.).largeChange(0.2).smallChange(0.1)
 
     let view model =
         VStack(spacing = 15.) {
             Slider(model.SliderValue1, ValueChanged1)
 
-            Slider(model.SliderValue2, ValueChanged2)
+            Slider(0., 100., model.SliderValue2, ValueChanged2)
                 .tickPlacement(TickPlacement.BottomRight)
                 .isSnapToTickEnabled(true)
                 .ticks([ 0.; 20.; 25.; 40.; 75.; 100. ])
                 .style(sliderStyle)
 
-            Slider(model.SliderValue3, ValueChanged3)
+            Slider(0., 100., model.SliderValue3, ValueChanged3)
                 .tickPlacement(TickPlacement.BottomRight)
                 .isSnapToTickEnabled(true)
                 .ticks([ 0.; 20.; 25.; 40.; 75.; 100. ])
@@ -74,22 +68,22 @@ module Slider =
                 .tooltipPlacement(PlacementMode.Top)
                 .style(sliderStyle)
 
-            Slider(model.SliderValue4, ValueChanged4)
+            Slider(0., 100., model.SliderValue4, ValueChanged4)
                 .dataValidationErrors([ Exception() ])
                 .style(sliderStyle)
 
-            Slider(model.SliderValue5, ValueChanged5)
+            Slider(0., 100., model.SliderValue5, ValueChanged5)
                 .isDirectionReversed(true)
                 .style(sliderStyle)
 
-            Slider(model.SliderValue6, ValueChanged6)
+            Slider(0., 100., model.SliderValue6, ValueChanged6)
                 .height(300.)
                 .orientation(Orientation.Vertical)
                 .tickPlacement(TickPlacement.Outside)
                 .isSnapToTickEnabled(true)
                 .style(sliderStyle)
 
-            Slider(model.SliderValue7, ValueChanged7)
+            Slider(0., 100., model.SliderValue7, ValueChanged7)
                 .height(300.)
                 .orientation(Orientation.Vertical)
                 .tickPlacement(TickPlacement.Outside)

--- a/samples/Gallery/Widgets/Transforms.fs
+++ b/samples/Gallery/Widgets/Transforms.fs
@@ -71,51 +71,27 @@ module Transforms =
 
             TextBlock("Center X: ").gridRow(1)
 
-            Slider(model.CenterX, CenterXChanged)
-                .gridRow(1)
-                .gridColumn(2)
-                .minimum(-100.)
-                .maximum(100.)
+            Slider(-100., 100., model.CenterX, CenterXChanged).gridRow(1).gridColumn(2)
 
             TextBlock("Center Y: ").gridRow(2)
 
-            Slider(model.CenterY, CenterYChanged)
-                .gridRow(2)
-                .gridColumn(2)
-                .minimum(-100.)
-                .maximum(100.)
+            Slider(-100., 100., model.CenterY, CenterYChanged).gridRow(2).gridColumn(2)
 
             TextBlock("Center Z: ").gridRow(3)
 
-            Slider(model.CenterZ, CenterZChanged)
-                .gridRow(3)
-                .gridColumn(2)
-                .minimum(-100.)
-                .maximum(100.)
+            Slider(-100., 100., model.CenterZ, CenterZChanged).gridRow(3).gridColumn(2)
 
             TextBlock("Angle X: ").gridRow(4)
 
-            Slider(model.AngleX, AngleXChanged)
-                .gridRow(4)
-                .gridColumn(2)
-                .minimum(-180.)
-                .maximum(180.)
+            Slider(-180., 180., model.AngleX, AngleXChanged).gridRow(4).gridColumn(2)
 
             TextBlock("Angle Y: ").gridRow(5)
 
-            Slider(model.AngleY, AngleYChanged)
-                .gridRow(5)
-                .gridColumn(2)
-                .minimum(-180.)
-                .maximum(180.)
+            Slider(-180., 180., model.AngleY, AngleYChanged).gridRow(5).gridColumn(2)
 
             TextBlock("Angle Z: ").gridRow(6)
 
-            Slider(model.AngleZ, AngleZChanged)
-                .gridRow(6)
-                .gridColumn(2)
-                .minimum(-180.)
-                .maximum(180.)
+            Slider(-180., 180., model.AngleZ, AngleZChanged).gridRow(6).gridColumn(2)
         }
 
     let sample =

--- a/samples/Gallery/Widgets/ViewBox.fs
+++ b/samples/Gallery/Widgets/ViewBox.fs
@@ -33,9 +33,9 @@ module ViewBox =
 
             (VStack() {
                 TextBlock($"Height: {model.Height}")
-                Slider(model.Height, HeightChanged).minimum(0.).maximum(300.)
+                Slider(0., 300., model.Height, HeightChanged)
                 TextBlock($"Width: {model.Width}")
-                Slider(model.Width, WidthChanged).minimum(0.).maximum(300.)
+                Slider(0., 300., model.Width, WidthChanged)
             })
                 .gridRow(0)
                 .gridColumn(1)

--- a/src/Fabulous.Avalonia/Views/Controls/Primitives/_RangeBase.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Primitives/_RangeBase.fs
@@ -36,12 +36,6 @@ module RangeBase =
     let MinimumMaximum =
         Attributes.defineSimpleScalarWithEquality<struct (float * float)> "RangeBase_MinimumMaximum" RangeBaseUpdaters.updateSliderMinMax
 
-    let Minimum =
-        Attributes.defineAvaloniaPropertyWithEquality RangeBase.MinimumProperty
-
-    let Maximum =
-        Attributes.defineAvaloniaPropertyWithEquality RangeBase.MaximumProperty
-
     let Value = Attributes.defineAvaloniaPropertyWithEquality RangeBase.ValueProperty
 
     let SmallChange =
@@ -55,19 +49,6 @@ module RangeBase =
 
 [<Extension>]
 type RangeBaserModifiers =
-
-    [<Extension>]
-    static member inline minimumMaximum(this: WidgetBuilder<'msg, #IFabRangeBase>, min: float, max: float) =
-        this.AddScalar(RangeBase.MinimumMaximum.WithValue(struct (min, max)))
-
-    [<Extension>]
-    static member inline minimum(this: WidgetBuilder<'msg, #IFabRangeBase>, value: float) =
-        this.AddScalar(RangeBase.Minimum.WithValue(value))
-
-    [<Extension>]
-    static member inline maximum(this: WidgetBuilder<'msg, #IFabRangeBase>, value: float) =
-        this.AddScalar(RangeBase.Maximum.WithValue(value))
-
     [<Extension>]
     static member inline smallChange(this: WidgetBuilder<'msg, #IFabRangeBase>, value: float) =
         this.AddScalar(RangeBase.SmallChange.WithValue(value))

--- a/src/Fabulous.Avalonia/Views/Controls/Slider.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Slider.fs
@@ -52,6 +52,14 @@ module SliderBuilders =
                 RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> onValueChanged args |> box))
             )
 
+        static member inline Slider<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
+            WidgetBuilder<'msg, IFabSlider>(
+                Slider.WidgetKey,
+                RangeBase.Value.WithValue(value),
+                RangeBase.MinimumMaximum.WithValue(min, max),
+                RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> onValueChanged args |> box))
+            )
+
 [<Extension>]
 type SliderModifiers =
     [<Extension>]

--- a/templates/content/blank/App.fs
+++ b/templates/content/blank/App.fs
@@ -65,7 +65,7 @@ module App =
                 .margin(20.)
                 .centerHorizontal()
 
-            Slider(double model.Step, SetStep).minimum(1.).maximum(10.)
+            Slider(1., 10, float model.Step, SetStep)
 
             TextBlock($"Step size: %d{model.Step}").centerText()
 


### PR DESCRIPTION
We need to have Min and Max update the Value simultaneously to ensure that the values are correct and prevent crashes.

- We can use this when you only care about the value, and the value changes and use what is default values

```fsharp
static member inline Slider<'msg>(value: float, onValueChanged: float -> 'msg) =
        WidgetBuilder<'msg, IFabSlider>(
            Slider.WidgetKey,
            RangeBase.Value.WithValue(value),
            RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> onValueChanged args |> box))
        )
```
- We can use this when you want to specify the min, max, value and listen fro the value changes

```fsharp
 static member inline Slider<'msg>(min: float, max: float, value: float, onValueChanged: float -> 'msg) =
     WidgetBuilder<'msg, IFabSlider>(
            Slider.WidgetKey,
            RangeBase.Value.WithValue(value),
            RangeBase.MinimumMaximum.WithValue(min, max),
            RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> onValueChanged args |> box))
    )
```