### PR TITLE
Set 'SupportedOSPlatformVersion' for 'Android' and 'iOS'.

### DIFF
--- a/samples/CounterApp/CounterApp.fsproj
+++ b/samples/CounterApp/CounterApp.fsproj
@@ -8,6 +8,12 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'iOS'">
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">
     <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
   </PropertyGroup>

--- a/samples/DrawingApp/DrawingApp.fsproj
+++ b/samples/DrawingApp/DrawingApp.fsproj
@@ -7,6 +7,12 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'iOS'">
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">
     <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
   </PropertyGroup>

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -9,6 +9,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'iOS'">
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">
     <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
   </PropertyGroup>

--- a/samples/GameOfLife/GameOfLife.fsproj
+++ b/samples/GameOfLife/GameOfLife.fsproj
@@ -7,6 +7,12 @@
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'iOS'">
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">
     <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
   </PropertyGroup>

--- a/samples/TicTacToe/TicTacToe.fsproj
+++ b/samples/TicTacToe/TicTacToe.fsproj
@@ -9,6 +9,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'iOS'">
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(AvaloniaPlatform)|$(Configuration)' == 'iOS|Debug' ">
     <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
   </PropertyGroup>

--- a/src/Fabulous.Avalonia.props
+++ b/src/Fabulous.Avalonia.props
@@ -16,6 +16,7 @@
     <PropertyGroup Condition="$(AvaloniaPlatform) == 'Android'">
         <AndroidPlatformFolder Condition="$(AndroidPlatformFolder) == ''">Platform\Android\</AndroidPlatformFolder>
         <AndroidManifest>$(AndroidPlatformFolder)AndroidManifest.xml</AndroidManifest>
+        <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
         <DefineConstants>MOBILE;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     

--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -12,6 +12,12 @@
     <AvaloniaPlatform Condition="'$(AvaloniaPlatform)' == 'android'">Android</AvaloniaPlatform>
     <AvaloniaPlatform Condition="'$(AvaloniaPlatform)' == 'ios'">iOS</AvaloniaPlatform>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'Android'">
+    <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(AvaloniaPlatform)' == 'iOS'">
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="App.fs" />
   </ItemGroup>


### PR DESCRIPTION
This pull request sets the 'SupportedOSPlatformVersion' build property for Android and iOS.

Motivation: Without it, deploying to my physical Android 12 device fails with "Requires newer sdk version #33": The minimal required Android version is apparently set to the highest available SDK version on the host machine when the property is not set.


The Android SDK version value of 21 is documented [here](https://docs.avaloniaui.net/tutorials/developing-for-mobile/android):

> Avalonia has support for same version of Android, [as MAUI](https://learn.microsoft.com/en-us/dotnet/maui/supported-platforms)

For iOS, this [article on the official Avalonia homepage](https://www.avaloniaui.net/Blog/avalonia-ui-and-maui-something-for-everyone,ce77d8d4-8dad-45ce-ae5a-566f3786571a) states:

> MAUI supports iOS 11 and higher, while Avalonia UI supports iOS 13.

However, there seems to be a mapping vom iOS version to `SupportedOSPlatformVersion`, as the official Avalonia project templates sets `SupportedOSPlatformVersion` to 10, which is done here accordingly.