### PR TITLE
Fix "Duplicate 'PackageReference' items found." warnings in templates project.

### DIFF
--- a/templates/content/blank/NewApp.fsproj
+++ b/templates/content/blank/NewApp.fsproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net7.0;net7.0-android</TargetFrameworks>
     <!-- net7.0-ios is not supported on Linux, so we do not add it there. -->
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net7.0-ios</TargetFrameworks>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
   <PropertyGroup>
     <AvaloniaPlatform>$([MSBuild]::GetTargetPlatformIdentifier($(TargetFramework)))</AvaloniaPlatform>


### PR DESCRIPTION
Building projects created via the the Fabulous.Avalonia templates result in warnings of the form

`[NU1504] Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: FSharp.Core 7.0.0, FSharp.Core 7.0.0.`

This seems to be caused by (or related to) [this dotnet/fsharp issue](https://github.com/dotnet/fsharp/issues/14441).

Respective warnings in the Fabulous.Avalonia repo itself are avoided by setting DisableImplicitFSharpCoreReference to true in the  [Directory.Build.props](https://github.com/fabulous-dev/Fabulous.Avalonia/blob/main/Directory.Build.props) file. This pull request sets it in the templates project as well.

