### PR TITLE
Type-safe events

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Fabulous" Version="2.3.2" />
+    <PackageVersion Include="Fabulous" Version="2.4.0" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
     <PackageVersion Include="FSharp.Android.Resource" Version="1.0.4" />
     <PackageVersion Include="FSharp.Core" Version="7.0.0" />

--- a/Fabulous.Avalonia.sln
+++ b/Fabulous.Avalonia.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solutio
 								pull_request.yml = .github/workflows/pull_request.yml
 								build.yml = .github/workflows/build.yml
 								release.yml = .github/workflows/release.yml
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabulous.Avalonia.Themes.Fluent", "src\Fabulous.Avalonia.Themes.Fluent\Fabulous.Avalonia.Themes.Fluent.fsproj", "{74A67DCD-5093-4CC6-B421-77376153C714}"

--- a/samples/Gallery/Pages/Pointers/PointerCanvasTab.fs
+++ b/samples/Gallery/Pages/Pointers/PointerCanvasTab.fs
@@ -238,5 +238,5 @@ module PointerCanvasTabBuilders =
                 PointerCanvas.WidgetKey,
                 PointerCanvas.DrawOnlyPoints.WithValue(drawingPoint),
                 PointerCanvas.ThreadSleep.WithValue(threadSleep),
-                PointerCanvas.StatusChanged.WithValue(fun args -> fn args |> box)
+                PointerCanvas.StatusChanged.WithValue(fn)
             )

--- a/src/Fabulous.Avalonia/Application.fs
+++ b/src/Fabulous.Avalonia/Application.fs
@@ -223,7 +223,7 @@ type ApplicationModifiers =
     /// <param name="fn">Raised when the theme variant changes.</param>
     [<Extension>]
     static member inline onThemeVariantChanged(this: WidgetBuilder<'msg, #IFabApplication>, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(Application.ThemeVariantChanged.WithValue(MsgValue (fn Application.Current.ActualThemeVariant)))
+        this.AddScalar(Application.ThemeVariantChanged.WithValue(MsgValue(fn Application.Current.ActualThemeVariant)))
 
     /// <summary>Listens to the application resources changed event.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Application.fs
+++ b/src/Fabulous.Avalonia/Application.fs
@@ -216,35 +216,35 @@ type ApplicationModifiers =
     /// <param name="fn">Raised when the theme variant changes.</param>
     [<Extension>]
     static member inline themeVariant(this: WidgetBuilder<'msg, #IFabApplication>, value: ThemeVariant, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(Application.ThemeVariant.WithValue(ValueEventData.create value (fun args -> fn args |> box)))
+        this.AddScalar(Application.ThemeVariant.WithValue(ValueEventData.create value fn))
 
     /// <summary>Listens to the application theme variant changed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the theme variant changes.</param>
     [<Extension>]
     static member inline onThemeVariantChanged(this: WidgetBuilder<'msg, #IFabApplication>, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(Application.ThemeVariantChanged.WithValue(fn Application.Current.ActualThemeVariant))
+        this.AddScalar(Application.ThemeVariantChanged.WithValue(MsgValue (fn Application.Current.ActualThemeVariant)))
 
     /// <summary>Listens to the application resources changed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the resources change.</param>
     [<Extension>]
     static member inline onResourcesChanged(this: WidgetBuilder<'msg, #IFabApplication>, fn: ResourcesChangedEventArgs -> 'msg) =
-        this.AddScalar(Application.ResourcesChanged.WithValue(fun target -> fn target |> box))
+        this.AddScalar(Application.ResourcesChanged.WithValue(fn))
 
     /// <summary>Listens to the application urls opened event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the application receives urls to open.</param>
     [<Extension>]
     static member inline onUrlsOpened(this: WidgetBuilder<'msg, #IFabApplication>, fn: UrlOpenedEventArgs -> 'msg) =
-        this.AddScalar(Application.UrlsOpened.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Application.UrlsOpened.WithValue(fn))
 
     /// <summary>Listens to the PlatformSettings color values changed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when current system color values are changed. Including changing of a dark mode and accent colors.</param>
     [<Extension>]
     static member inline onColorValuesChanged(this: WidgetBuilder<'msg, #IFabApplication>, fn: Platform.PlatformColorValues -> 'msg) =
-        this.AddScalar(Application.ColorValuesChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Application.ColorValuesChanged.WithValue(fn))
 
     /// <summary>Links a ViewRef to access the direct Application control instance</summary>
     /// <param name="this">Current widget</param>

--- a/src/Fabulous.Avalonia/Attributes.fs
+++ b/src/Fabulous.Avalonia/Attributes.fs
@@ -18,9 +18,10 @@ module ValueEventData =
     let create (value: 'data) (event: 'eventArgs -> 'msg) =
         { Value = ValueSome value
           Event = event >> box >> MsgValue }
-        
+
     let createVOption (value: 'data voption) (event: 'eventArgs -> 'msg) =
-        { Value = value; Event = event >> box >> MsgValue }
+        { Value = value
+          Event = event >> box >> MsgValue }
 
 module Attributes =
     /// Define an attribute for EventHandler<'T>

--- a/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
+++ b/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
@@ -225,7 +225,7 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
-    <PackageReference Include="Fabulous" VersionOverride="[2.3.1, 2.4.0)" />
+    <PackageReference Include="Fabulous" VersionOverride="[2.4.0, 2.5.0)" />
     <PackageReference Include="Avalonia" VersionOverride="11.0.0" />
     <PackageReference Include="Avalonia.Skia" VersionOverride="11.0.0" />
     <PackageReference Include="Avalonia.Themes.Fluent" VersionOverride="11.0.0" />

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -76,7 +76,7 @@ module AutoCompleteBoxBuilders =
             WidgetBuilder<'msg, IFabAutoCompleteBox>(
                 AutoCompleteBox.WidgetKey,
                 AutoCompleteBox.ItemsSource.WithValue(items),
-                AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text (fun args -> fn args |> box))
+                AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn)
             )
 
         /// <summary>Creates a CalendarDatePicker widget.</summary>
@@ -87,7 +87,7 @@ module AutoCompleteBoxBuilders =
             WidgetBuilder<'msg, IFabAutoCompleteBox>(
                 AutoCompleteBox.WidgetKey,
                 AutoCompleteBox.AsyncPopulator.WithValue(populator),
-                AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text (fun args -> fn args |> box))
+                AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn)
             )
 
 [<Extension>]
@@ -164,14 +164,14 @@ type AutoCompleteBoxModifiers =
 
     [<Extension>]
     static member inline onPopulating(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, fn: PopulatingEventArgs -> 'msg) =
-        this.AddScalar(AutoCompleteBox.Populating.WithValue(fun args -> fn args |> box))
+        this.AddScalar(AutoCompleteBox.Populating.WithValue(fn))
 
     /// <summary>Listens to the AutoCompleteBox Populated event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the AutoCompleteBox Populated event is fired.</param>
     [<Extension>]
     static member inline onPopulated(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, fn: PopulatedEventArgs -> 'msg) =
-        this.AddScalar(AutoCompleteBox.Populated.WithValue(fun args -> fn args |> box))
+        this.AddScalar(AutoCompleteBox.Populated.WithValue(fn))
 
     /// <summary>Listens to the AutoCompleteBox DropDownOpened event.</summary>
     /// <param name="this">Current widget.</param>
@@ -179,14 +179,14 @@ type AutoCompleteBoxModifiers =
     /// <param name="fn">Raised when the AutoCompleteBox DropDownOpened event is fired.</param>
     [<Extension>]
     static member inline onDropDownOpened(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, isOpen: bool, fn: bool -> 'msg) =
-        this.AddScalar(AutoCompleteBox.DropDownOpened.WithValue(ValueEventData.create isOpen (fun args -> fn args |> box)))
+        this.AddScalar(AutoCompleteBox.DropDownOpened.WithValue(ValueEventData.create isOpen fn))
 
     /// <summary>Listens to the AutoCompleteBox SelectionChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the AutoCompleteBox SelectionChanged event is fired.</param>
     [<Extension>]
     static member inline onSelectionChanged(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, fn: SelectionChangedEventArgs -> 'msg) =
-        this.AddScalar(AutoCompleteBox.SelectionChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(AutoCompleteBox.SelectionChanged.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct AutoCompleteBox control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/ButtonSpinner.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/ButtonSpinner.fs
@@ -27,11 +27,7 @@ module ButtonSpinnerBuilders =
         /// <param name="text">The text to display.</param>
         /// <param name="fn">Raised when the ButtonSpinner is clicked.</param>
         static member inline ButtonSpinner<'msg>(text: string, fn: SpinEventArgs -> 'msg) =
-            WidgetBuilder<'msg, IFabButtonSpinner>(
-                ButtonSpinner.WidgetKey,
-                ContentControl.ContentString.WithValue(text),
-                Spinner.Spin.WithValue(fn)
-            )
+            WidgetBuilder<'msg, IFabButtonSpinner>(ButtonSpinner.WidgetKey, ContentControl.ContentString.WithValue(text), Spinner.Spin.WithValue(fn))
 
 [<Extension>]
 type ButtonSpinnerModifiers =

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/ButtonSpinner.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/ButtonSpinner.fs
@@ -30,7 +30,7 @@ module ButtonSpinnerBuilders =
             WidgetBuilder<'msg, IFabButtonSpinner>(
                 ButtonSpinner.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                Spinner.Spin.WithValue(fun args -> fn args |> box)
+                Spinner.Spin.WithValue(fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/DropDownButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/DropDownButton.fs
@@ -18,22 +18,22 @@ module DropDownButtonBuilders =
 
         /// <summary>Creates a DropDownButton widget.</summary>
         /// <param name="text">The text to display.</param>
-        /// <param name="fn">Raised when the DropDownButton is clicked.</param>
-        static member inline DropDownButton<'msg>(text: string, fn: 'msg) =
+        /// <param name="msg">Raised when the DropDownButton is clicked.</param>
+        static member inline DropDownButton<'msg>(text: string, msg: 'msg) =
             WidgetBuilder<'msg, IFabDropDownButton>(
                 DropDownButton.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                Button.Clicked.WithValue(fun _ -> box fn |> box)
+                Button.Clicked.WithValue(fun _ -> box msg)
             )
 
         /// <summary>Creates a DropDownButton widget.</summary>
-        /// <param name="fn">Raised when the DropDownButton is clicked.</param>
+        /// <param name="msg">Raised when the DropDownButton is clicked.</param>
         /// <param name="content">The content of the DropDownButton.</param>
-        static member inline DropDownButton(fn: 'msg, content: WidgetBuilder<'msg, #IFabControl>) =
+        static member inline DropDownButton(msg: 'msg, content: WidgetBuilder<'msg, #IFabControl>) =
             WidgetBuilder<'msg, IFabDropDownButton>(
                 DropDownButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(Button.Clicked.WithValue(fun _ -> fn |> box)),
+                    StackList.one(Button.Clicked.WithValue(fun _ -> box msg)),
                     ValueSome [| ContentControl.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/RadioButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/RadioButton.fs
@@ -26,7 +26,7 @@ module RadioButtonBuilders =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))
+                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
             )
 
         /// <summary>Creates a ThreeStateRadioButton widget.</summary>
@@ -39,7 +39,7 @@ module RadioButtonBuilders =
                 ToggleButton.IsThreeState.WithValue(true),
                 ContentControl.ContentString.WithValue(text),
                 ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                 )
             )
 
@@ -51,7 +51,7 @@ module RadioButtonBuilders =
             WidgetBuilder<'msg, IFabRadioButton>(
                 RadioButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))),
+                    StackList.one(ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)),
                     ValueSome [| ContentControl.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )
@@ -67,7 +67,7 @@ module RadioButtonBuilders =
                 AttributesBundle(
                     StackList.two(
                         ToggleButton.ThreeStateCheckedChanged.WithValue(
-                            ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                            ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                         ),
                         ToggleButton.IsThreeState.WithValue(true)
                     ),

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/RadioButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/RadioButton.fs
@@ -38,9 +38,7 @@ module RadioButtonBuilders =
                 RadioButton.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(true),
                 ContentControl.ContentString.WithValue(text),
-                ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
-                )
+                ToggleButton.ThreeStateCheckedChanged.WithValue(ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn))
             )
 
         /// <summary>Creates a RadioButton widget.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/RepeatButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/RepeatButton.fs
@@ -22,12 +22,12 @@ module RepeatButtonBuilders =
 
         /// <summary>Creates a RepeatButton widget.</summary>
         /// <param name="text">The text to display.</param>
-        /// <param name="fn">Raised when the button is clicked.</param>
-        static member inline RepeatButton<'msg>(text: string, fn: 'msg) =
+        /// <param name="msg">Raised when the button is clicked.</param>
+        static member inline RepeatButton<'msg>(text: string, msg: 'msg) =
             WidgetBuilder<'msg, IFabRepeatButton>(
                 RepeatButton.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                Button.Clicked.WithValue(fun _ -> fn |> box)
+                Button.Clicked.WithValue(fun _ -> box msg)
             )
 
         /// <summary>Creates a RepeatButton widget.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/ToggleButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/ToggleButton.fs
@@ -48,7 +48,7 @@ module ToggleButtonBuilders =
             WidgetBuilder<'msg, IFabToggleButton>(
                 ToggleButton.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))
+                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
             )
 
         /// <summary>Creates a ThreeStateToggleButton widget.</summary>
@@ -61,7 +61,7 @@ module ToggleButtonBuilders =
                 ContentControl.ContentString.WithValue(text),
                 ToggleButton.IsThreeState.WithValue(true),
                 ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                 )
             )
 
@@ -73,7 +73,7 @@ module ToggleButtonBuilders =
             WidgetBuilder<'msg, IFabToggleButton>(
                 ToggleButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))),
+                    StackList.one(ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)),
                     ValueSome [| ContentControl.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )
@@ -89,7 +89,7 @@ module ToggleButtonBuilders =
                 AttributesBundle(
                     StackList.two(
                         ToggleButton.ThreeStateCheckedChanged.WithValue(
-                            ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                            ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                         ),
                         ToggleButton.IsThreeState.WithValue(true)
                     ),

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/ToggleButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/ToggleButton.fs
@@ -60,9 +60,7 @@ module ToggleButtonBuilders =
                 ToggleButton.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
                 ToggleButton.IsThreeState.WithValue(true),
-                ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
-                )
+                ToggleButton.ThreeStateCheckedChanged.WithValue(ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn))
             )
 
         /// <summary>Creates a ToggleButton widget.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/Buttons/ToggleSplitButton.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Buttons/ToggleSplitButton.fs
@@ -26,7 +26,7 @@ module ToggleSplitButtonBuilders =
             WidgetBuilder<'msg, IFabToggleSplitButton>(
                 ToggleSplitButton.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                ToggleSplitButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))
+                ToggleSplitButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
             )
 
         /// <summary>Creates a ToggleSplitButton widget.</summary>
@@ -37,7 +37,7 @@ module ToggleSplitButtonBuilders =
             WidgetBuilder<'msg, IFabToggleSplitButton>(
                 ToggleSplitButton.WidgetKey,
                 AttributesBundle(
-                    StackList.one(ToggleSplitButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))),
+                    StackList.one(ToggleSplitButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)),
                     ValueSome [| ContentControl.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )

--- a/src/Fabulous.Avalonia/Views/Controls/Calendar.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Calendar.fs
@@ -60,7 +60,7 @@ module CalendarBuilders =
             WidgetBuilder<'msg, IFabCalendar>(
                 Calendar.WidgetKey,
                 Calendar.SelectionMode.WithValue(CalendarSelectionMode.SingleDate),
-                Calendar.SelectedDateChanged.WithValue(ValueEventData.create date (fun args -> fn args |> box))
+                Calendar.SelectedDateChanged.WithValue(ValueEventData.create date fn)
             )
 
         /// <summary>Creates a Calendar widget.</summary>
@@ -71,7 +71,7 @@ module CalendarBuilders =
             WidgetBuilder<'msg, IFabCalendar>(
                 Calendar.WidgetKey,
                 Calendar.SelectionMode.WithValue(mode),
-                Calendar.SelectedDateChanged.WithValue(ValueEventData.create date (fun args -> fn args |> box))
+                Calendar.SelectedDateChanged.WithValue(ValueEventData.create date fn)
             )
 
 [<Extension>]
@@ -144,14 +144,14 @@ type CalendarModifiers =
     /// <param name="fn">Raised when the DisplayDateChanged event is fired.</param>
     [<Extension>]
     static member inline onDisplayDateChanged(this: WidgetBuilder<'msg, #IFabCalendar>, fn: CalendarDateChangedEventArgs -> 'msg) =
-        this.AddScalar(Calendar.DisplayDateChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Calendar.DisplayDateChanged.WithValue(fn))
 
     /// <summary>Listens to the Calendar DisplayModeChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the DisplayModeChanged event is fired.</param>
     [<Extension>]
     static member inline onDisplayModeChanged(this: WidgetBuilder<'msg, #IFabCalendar>, fn: CalendarModeChangedEventArgs -> 'msg) =
-        this.AddScalar(Calendar.DisplayModeChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Calendar.DisplayModeChanged.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct Calendar control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/CalendarDatePicker.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/CalendarDatePicker.fs
@@ -77,7 +77,7 @@ module CalendarDatePickerBuilders =
         static member CalendarDatePicker(date: DateTime option, fn: DateTime option -> 'msg) =
             WidgetBuilder<'msg, IFabCalendarDatePicker>(
                 CalendarDatePicker.WidgetKey,
-                CalendarDatePicker.SelectedDateChanged.WithValue(ValueEventData.create date (fun args -> fn args |> box))
+                CalendarDatePicker.SelectedDateChanged.WithValue(ValueEventData.create date fn)
             )
 
 [<Extension>]
@@ -178,21 +178,21 @@ type CalendarDatePickerModifiers =
     /// <param name="fn">Raised when the DatePicker detects a format error.</param>
     [<Extension>]
     static member inline onDateValidationError(this: WidgetBuilder<'msg, #IFabCalendarDatePicker>, fn: CalendarDatePickerDateValidationErrorEventArgs -> 'msg) =
-        this.AddScalar(CalendarDatePicker.DateValidationError.WithValue(fun args -> fn args |> box))
+        this.AddScalar(CalendarDatePicker.DateValidationError.WithValue(fn))
 
     /// <summary>Listens to the CalendarDatePicker CalendarClosed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the DatePicker closes its calendar.</param>
+    /// <param name="msg">Raised when the DatePicker closes its calendar.</param>
     [<Extension>]
-    static member inline onCalendarClosed(this: WidgetBuilder<'msg, #IFabCalendarDatePicker>, fn: 'msg) =
-        this.AddScalar(CalendarDatePicker.CalendarClosed.WithValue(fn))
+    static member inline onCalendarClosed(this: WidgetBuilder<'msg, #IFabCalendarDatePicker>, msg: 'msg) =
+        this.AddScalar(CalendarDatePicker.CalendarClosed.WithValue(MsgValue msg))
 
     /// <summary>Listens to the CalendarDatePicker CalendarOpened event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the DatePicker opens its calendar.</param>
+    /// <param name="msg">Raised when the DatePicker opens its calendar.</param>
     [<Extension>]
-    static member inline onCalendarOpened(this: WidgetBuilder<'msg, #IFabCalendarDatePicker>, fn: 'msg) =
-        this.AddScalar(CalendarDatePicker.CalendarOpened.WithValue(fn))
+    static member inline onCalendarOpened(this: WidgetBuilder<'msg, #IFabCalendarDatePicker>, msg: 'msg) =
+        this.AddScalar(CalendarDatePicker.CalendarOpened.WithValue(MsgValue msg))
 
     /// <summary>Link a ViewRef to access the direct CalendarDatePicker control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/CheckBox.fs
@@ -21,10 +21,7 @@ module CheckBoxBuilders =
         /// <param name="isChecked">Whether the CheckBox is checked.</param>
         /// <param name="fn">Raised when the CheckBox is clicked.</param>
         static member inline CheckBox<'msg>(isChecked: bool, fn: bool -> 'msg) =
-            WidgetBuilder<'msg, IFabCheckBox>(
-                CheckBox.WidgetKey,
-                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
-            )
+            WidgetBuilder<'msg, IFabCheckBox>(CheckBox.WidgetKey, ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn))
 
         /// <summary>Creates a CheckBox widget.</summary>
         /// <param name="text">The CheckBox text.</param>
@@ -58,9 +55,7 @@ module CheckBoxBuilders =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(true),
-                ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
-                )
+                ToggleButton.ThreeStateCheckedChanged.WithValue(ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn))
             )
 
         /// <summary>Creates a ThreeStateCheckBox widget.</summary>
@@ -72,9 +67,7 @@ module CheckBoxBuilders =
                 CheckBox.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(true),
                 ContentControl.ContentString.WithValue(text),
-                ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
-                )
+                ToggleButton.ThreeStateCheckedChanged.WithValue(ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn))
             )
 
         /// <summary>Creates a ThreeStateCheckBox widget.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/CheckBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/CheckBox.fs
@@ -23,7 +23,7 @@ module CheckBoxBuilders =
         static member inline CheckBox<'msg>(isChecked: bool, fn: bool -> 'msg) =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
-                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))
+                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
             )
 
         /// <summary>Creates a CheckBox widget.</summary>
@@ -34,7 +34,7 @@ module CheckBoxBuilders =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
                 ContentControl.ContentString.WithValue(text),
-                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))
+                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
             )
 
         /// <summary>Creates a CheckBox widget</summary>
@@ -45,7 +45,7 @@ module CheckBoxBuilders =
             WidgetBuilder<'msg, IFabCheckBox>(
                 CheckBox.WidgetKey,
                 AttributesBundle(
-                    StackList.one(ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))),
+                    StackList.one(ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)),
                     ValueSome [| ContentControl.ContentWidget.WithValue(content.Compile()) |],
                     ValueNone
                 )
@@ -59,7 +59,7 @@ module CheckBoxBuilders =
                 CheckBox.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(true),
                 ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                 )
             )
 
@@ -73,7 +73,7 @@ module CheckBoxBuilders =
                 ToggleButton.IsThreeState.WithValue(true),
                 ContentControl.ContentString.WithValue(text),
                 ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                 )
             )
 
@@ -87,7 +87,7 @@ module CheckBoxBuilders =
                 AttributesBundle(
                     StackList.two(
                         ToggleButton.ThreeStateCheckedChanged.WithValue(
-                            ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                            ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                         ),
                         ToggleButton.IsThreeState.WithValue(true)
                     ),

--- a/src/Fabulous.Avalonia/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/DatePicker.fs
@@ -46,10 +46,7 @@ module DatePickerBuilders =
         /// <param name="date">The initial date.</param>
         /// <param name="fn">Raised when the selected date changes.</param>
         static member inline DatePicker(date: DateTimeOffset, fn: DateTimeOffset -> 'msg) =
-            WidgetBuilder<'msg, IFabDatePicker>(
-                DatePicker.WidgetKey,
-                DatePicker.SelectedDateChanged.WithValue(ValueEventData.create date fn)
-            )
+            WidgetBuilder<'msg, IFabDatePicker>(DatePicker.WidgetKey, DatePicker.SelectedDateChanged.WithValue(ValueEventData.create date fn))
 
 [<Extension>]
 type DatePickerModifiers =

--- a/src/Fabulous.Avalonia/Views/Controls/DatePicker.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/DatePicker.fs
@@ -48,7 +48,7 @@ module DatePickerBuilders =
         static member inline DatePicker(date: DateTimeOffset, fn: DateTimeOffset -> 'msg) =
             WidgetBuilder<'msg, IFabDatePicker>(
                 DatePicker.WidgetKey,
-                DatePicker.SelectedDateChanged.WithValue(ValueEventData.create date (fun args -> fn args |> box))
+                DatePicker.SelectedDateChanged.WithValue(ValueEventData.create date fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/Expander.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Expander.fs
@@ -115,21 +115,21 @@ type ExpanderModifiers =
     /// <param name="fn">Raised when the ExpandedChanged event fires.</param>
     [<Extension>]
     static member inline onExpandedChanged(this: WidgetBuilder<'msg, #IFabExpander>, isExpanded: bool, fn: bool -> 'msg) =
-        this.AddScalar(Expander.ExpandedChanged.WithValue(ValueEventData.create isExpanded (fun arg -> fn arg |> box)))
+        this.AddScalar(Expander.ExpandedChanged.WithValue(ValueEventData.create isExpanded fn))
 
     /// <summary>Listens to the Expander Collapsing event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the Collapsing event fires.</param>
     [<Extension>]
     static member inline onCollapsing(this: WidgetBuilder<'msg, #IFabExpander>, fn: CancelRoutedEventArgs -> 'msg) =
-        this.AddScalar(Expander.Collapsing.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Expander.Collapsing.WithValue(fn))
 
     /// <summary>Listens to the Expander Expanding event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the Expanding event fires.</param>
     [<Extension>]
     static member inline onExpanding(this: WidgetBuilder<'msg, #IFabExpander>, fn: CancelRoutedEventArgs -> 'msg) =
-        this.AddScalar(Expander.Expanding.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Expander.Expanding.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct Expander control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/ExperimentalAcrylicMaterial.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/ExperimentalAcrylicMaterial.fs
@@ -90,10 +90,10 @@ type ExperimentalAcrylicMaterialModifiers =
 
     /// <summary>Listens the ExperimentalAcrylicMaterial Invalidated event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the ExperimentalAcrylicMaterial is invalidated.</param>
+    /// <param name="msg">Raised when the ExperimentalAcrylicMaterial is invalidated.</param>
     [<Extension>]
-    static member inline onInvalidated(this: WidgetBuilder<'msg, #IFabExperimentalAcrylicMaterial>, fn: 'msg) =
-        this.AddScalar(ExperimentalAcrylicMaterial.Invalidated.WithValue(fun _ -> fn |> box))
+    static member inline onInvalidated(this: WidgetBuilder<'msg, #IFabExperimentalAcrylicMaterial>, msg: 'msg) =
+        this.AddScalar(ExperimentalAcrylicMaterial.Invalidated.WithValue(MsgValue msg))
 
     /// <summary>Link a ViewRef to access the direct ExperimentalAcrylicMaterial control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/MaskedTextBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/MaskedTextBox.fs
@@ -46,7 +46,7 @@ module MaskedTextBoxBuilders =
             WidgetBuilder<'msg, IFabMaskedTextBox>(
                 MaskedTextBox.WidgetKey,
                 MaskedTextBox.Mask.WithValue(mask),
-                TextBox.TextChanged.WithValue(ValueEventData.create text (fun args -> fn args |> box))
+                TextBox.TextChanged.WithValue(ValueEventData.create text fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/NotificationCard.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/NotificationCard.fs
@@ -46,7 +46,7 @@ type NotificationCardModifiers =
     /// <param name="fn">Raised when the NotificationCard is closed.</param>
     [<Extension>]
     static member inline onNotificationClosed(this: WidgetBuilder<'msg, #IFabNotificationCard>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(NotificationCard.NotificationClosed.WithValue(fun args -> fn args |> box))
+        this.AddScalar(NotificationCard.NotificationClosed.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct NotificationCard control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/NumericUpDown.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/NumericUpDown.fs
@@ -100,13 +100,7 @@ module NumericUpDownBuilders =
                         | Some v -> Some(decimal v)
                         | None -> None
 
-                    ValueEventData.create value (fun args ->
-                        let args =
-                            match args with
-                            | Some v -> Some(float v)
-                            | None -> None
-
-                        fn args |> box)
+                    ValueEventData.create value (Option.map float >> fn)
                 )
             )
 
@@ -118,20 +112,14 @@ module NumericUpDownBuilders =
         static member inline NumericUpDown<'msg>(min: float, max: float, value: float option, fn: float option -> 'msg) =
             WidgetBuilder<'msg, IFabNumericUpDown>(
                 NumericUpDown.WidgetKey,
-                NumericUpDown.MinimumMaximum.WithValue(decimal min, decimal max),
+                NumericUpDown.MinimumMaximum.WithValue(struct (decimal min, decimal max)),
                 NumericUpDown.ValueChanged.WithValue(
                     let value =
                         match value with
                         | Some v -> Some(decimal v)
                         | None -> None
 
-                    ValueEventData.create value (fun args ->
-                        let args =
-                            match args with
-                            | Some v -> Some(float v)
-                            | None -> None
-
-                        fn args |> box)
+                    ValueEventData.create value (Option.map float >> fn)
                 )
             )
 

--- a/src/Fabulous.Avalonia/Views/Controls/Primitives/Popup.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Primitives/Popup.fs
@@ -183,17 +183,17 @@ type PopupModifiers =
 
     /// <summary>Listens to the Popup Closed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Popup is closed.</param>
+    /// <param name="msg">Raised when the Popup is closed.</param>
     [<Extension>]
-    static member inline onClosed(this: WidgetBuilder<'msg, #IFabPopup>, fn: 'msg) =
-        this.AddScalar(Popup.Closed.WithValue(fun _ -> fn |> box))
+    static member inline onClosed(this: WidgetBuilder<'msg, #IFabPopup>, msg: 'msg) =
+        this.AddScalar(Popup.Closed.WithValue(fun _ -> box msg))
 
     /// <summary>Listens to the Popup Opened event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Popup is opened.</param>
+    /// <param name="msg">Raised when the Popup is opened.</param>
     [<Extension>]
-    static member inline onOpened(this: WidgetBuilder<'msg, #IFabPopup>, fn: 'msg) =
-        this.AddScalar(Popup.Opened.WithValue(fn))
+    static member inline onOpened(this: WidgetBuilder<'msg, #IFabPopup>, msg: 'msg) =
+        this.AddScalar(Popup.Opened.WithValue(MsgValue msg))
 
     /// <summary>Link a ViewRef to access the direct Popup control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/Primitives/ScrollBar.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Primitives/ScrollBar.fs
@@ -45,8 +45,8 @@ module ScrollBarBuilders =
         static member inline ScrollBar(min: float, max: float, value: float, fn: float -> 'msg) =
             WidgetBuilder<'msg, IFabScrollBar>(
                 ScrollBar.WidgetKey,
-                RangeBase.MinimumMaximum.WithValue(min, max),
-                RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> fn args |> box))
+                RangeBase.MinimumMaximum.WithValue(struct (min, max)),
+                RangeBase.ValueChanged.WithValue(ValueEventData.create value fn)
             )
 
 [<Extension>]
@@ -99,7 +99,7 @@ type ScrollBarModifiers =
     /// <param name="fn">Raised when the Scroll value changes.</param>
     [<Extension>]
     static member inline onScroll(this: WidgetBuilder<'msg, #IFabScrollBar>, fn: ScrollEventArgs -> 'msg) =
-        this.AddScalar(ScrollBar.Scroll.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ScrollBar.Scroll.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct ScrollBar control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/Primitives/_RangeBase.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Primitives/_RangeBase.fs
@@ -66,18 +66,18 @@ type RangeBaserModifiers =
     /// <param name="fn">Raised when the Thumb dragged started.</param>
     [<Extension>]
     static member inline onDragStarted(this: WidgetBuilder<'msg, #IFabRangeBase>, fn: VectorEventArgs -> 'msg) =
-        this.AddScalar(Thumb.DragStarted.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Thumb.DragStarted.WithValue(fn))
 
     /// <summary>Listens to the Thumb DragDelta event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the Thumb dragged.</param>
     [<Extension>]
     static member inline onDragDelta(this: WidgetBuilder<'msg, #IFabRangeBase>, fn: VectorEventArgs -> 'msg) =
-        this.AddScalar(Thumb.DragDelta.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Thumb.DragDelta.WithValue(fn))
 
     /// <summary>Listens to the Thumb DragCompleted event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the Thumb dragged is completed.</param>
     [<Extension>]
     static member inline onDragCompleted(this: WidgetBuilder<'msg, #IFabRangeBase>, fn: VectorEventArgs -> 'msg) =
-        this.AddScalar(Thumb.DragCompleted.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Thumb.DragCompleted.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/Controls/ProgressBar.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/ProgressBar.fs
@@ -39,8 +39,8 @@ module ProgressBarBuilders =
         static member inline ProgressBar<'msg>(min: float, max: float, value: float, fn: float -> 'msg) =
             WidgetBuilder<'msg, IFabProgressBar>(
                 ProgressBar.WidgetKey,
-                RangeBase.MinimumMaximum.WithValue(min, max),
-                RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> fn args |> box))
+                RangeBase.MinimumMaximum.WithValue(struct (min, max)),
+                RangeBase.ValueChanged.WithValue(ValueEventData.create value fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/RefreshContainer.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/RefreshContainer.fs
@@ -55,7 +55,7 @@ type RefreshContainerModifiers =
     /// <param name="fn">Raised when the RefreshRequested event is fired.</param>
     [<Extension>]
     static member inline onRefreshRequested(this: WidgetBuilder<'msg, #IFabRefreshContainer>, fn: RefreshRequestedEventArgs -> 'msg) =
-        this.AddScalar(RefreshContainer.RefreshRequested.WithValue(fun args -> fn args |> box))
+        this.AddScalar(RefreshContainer.RefreshRequested.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct RefreshContainer control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/RefreshVisualizer.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/RefreshVisualizer.fs
@@ -45,7 +45,7 @@ type RefreshVisualizerModifiers =
     /// <param name="fn">Raised when the RefreshRequested event is fired.</param>
     [<Extension>]
     static member inline onRefreshRequested(this: WidgetBuilder<'msg, #IFabRefreshVisualizer>, fn: RefreshRequestedEventArgs -> 'msg) =
-        this.AddScalar(RefreshVisualizer.RefreshRequested.WithValue(fun args -> fn args |> box))
+        this.AddScalar(RefreshVisualizer.RefreshRequested.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct RefreshContainer control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/SelectableTextBlock.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/SelectableTextBlock.fs
@@ -40,7 +40,7 @@ module SelectableTextBlockBuilders =
             WidgetBuilder<'msg, IFabSelectableTextBlock>(
                 SelectableTextBlock.WidgetKey,
                 TextBlock.Text.WithValue(text),
-                SelectableTextBlock.CopyingToClipboard.WithValue(fun args -> fn args |> box)
+                SelectableTextBlock.CopyingToClipboard.WithValue(fn)
             )
 
         /// <summary>Creates a SelectableTextBlock widget.</summary>
@@ -49,7 +49,7 @@ module SelectableTextBlockBuilders =
             CollectionBuilder<'msg, IFabSelectableTextBlock, IFabInline>(
                 SelectableTextBlock.WidgetKey,
                 TextBlock.Inlines,
-                SelectableTextBlock.CopyingToClipboard.WithValue(fun args -> fn args |> box)
+                SelectableTextBlock.CopyingToClipboard.WithValue(fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/Slider.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Slider.fs
@@ -48,7 +48,7 @@ module SliderBuilders =
         /// <param name="value">The initial value of the slider.</param>
         /// <param name="fn">Raised when the slider value changes.</param>
         static member inline Slider<'msg>(value: float, fn: float -> 'msg) =
-            WidgetBuilder<'msg, IFabSlider>(Slider.WidgetKey, RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> fn args |> box)))
+            WidgetBuilder<'msg, IFabSlider>(Slider.WidgetKey, RangeBase.ValueChanged.WithValue(ValueEventData.create value fn))
 
         /// <summary>Creates a Slider widget.</summary>
         /// <param name="min">The minimum value of the slider.</param>
@@ -58,8 +58,8 @@ module SliderBuilders =
         static member inline Slider<'msg>(min: float, max: float, value: float, fn: float -> 'msg) =
             WidgetBuilder<'msg, IFabSlider>(
                 Slider.WidgetKey,
-                RangeBase.MinimumMaximum.WithValue(min, max),
-                RangeBase.ValueChanged.WithValue(ValueEventData.create value (fun args -> fn args |> box))
+                RangeBase.MinimumMaximum.WithValue(struct (min, max)),
+                RangeBase.ValueChanged.WithValue(ValueEventData.create value fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/TextBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/TextBox.fs
@@ -120,7 +120,7 @@ module TextBoxBuilders =
         /// <param name="text">The text to display.</param>
         /// <param name="fn">Raised when the text changes.</param>
         static member inline TextBox<'msg>(text: string, fn: string -> 'msg) =
-            WidgetBuilder<'msg, IFabTextBox>(TextBox.WidgetKey, TextBox.TextChanged.WithValue(ValueEventData.create text (fun args -> fn args |> box)))
+            WidgetBuilder<'msg, IFabTextBox>(TextBox.WidgetKey, TextBox.TextChanged.WithValue(ValueEventData.create text fn))
 
 [<Extension>]
 type TextBoxModifiers =
@@ -354,21 +354,21 @@ type TextBoxModifiers =
     /// <param name="fn">Raised when the CopyingToClipboard changes.</param>
     [<Extension>]
     static member inline onCopyingToClipboard(this: WidgetBuilder<'msg, #IFabTextBox>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(TextBox.CopyingToClipboard.WithValue(fun args -> fn args |> box))
+        this.AddScalar(TextBox.CopyingToClipboard.WithValue(fn))
 
     /// <summary>Listens to the TexBox CuttingToClipboard event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the CuttingToClipboard changes.</param>
     [<Extension>]
     static member inline onCuttingToClipboard(this: WidgetBuilder<'msg, #IFabTextBox>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(TextBox.CuttingToClipboard.WithValue(fun args -> fn args |> box))
+        this.AddScalar(TextBox.CuttingToClipboard.WithValue(fn))
 
     /// <summary>Listens to the TexBox PastingFromClipboard event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the PastingFromClipboard changes.</param>
     [<Extension>]
     static member inline onPastingFromClipboard(this: WidgetBuilder<'msg, #IFabTextBox>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(TextBox.PastingFromClipboard.WithValue(fun args -> fn args |> box))
+        this.AddScalar(TextBox.PastingFromClipboard.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct TextBox control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/ThemeVariantScope.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/ThemeVariantScope.fs
@@ -44,7 +44,7 @@ type ThemeVariantScopeModifiers =
     /// <param name="fn">Raised when the ThemeVariantChanged event is raised.</param>
     [<Extension>]
     static member inline onThemeVariantChanged(this: WidgetBuilder<'msg, #IFabThemeVariantScope>, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(ThemeVariantScope.ThemeVariantChanged.WithValue(fn Application.Current.ActualThemeVariant))
+        this.AddScalar(ThemeVariantScope.ThemeVariantChanged.WithValue(MsgValue (fn Application.Current.ActualThemeVariant)))
 
     /// <summary>Link a ViewRef to access the direct ThemeVariantScope control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/ThemeVariantScope.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/ThemeVariantScope.fs
@@ -44,7 +44,7 @@ type ThemeVariantScopeModifiers =
     /// <param name="fn">Raised when the ThemeVariantChanged event is raised.</param>
     [<Extension>]
     static member inline onThemeVariantChanged(this: WidgetBuilder<'msg, #IFabThemeVariantScope>, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(ThemeVariantScope.ThemeVariantChanged.WithValue(MsgValue (fn Application.Current.ActualThemeVariant)))
+        this.AddScalar(ThemeVariantScope.ThemeVariantChanged.WithValue(MsgValue(fn Application.Current.ActualThemeVariant)))
 
     /// <summary>Link a ViewRef to access the direct ThemeVariantScope control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/TimePicker.fs
@@ -28,10 +28,7 @@ module TimePickerBuilders =
         /// <param name="time">The initial time.</param>
         /// <param name="fn">Raised when the selected time changes.</param>
         static member inline TimePicker(time: TimeSpan, fn: TimeSpan -> 'msg) =
-            WidgetBuilder<'msg, IFabTimePicker>(
-                TimePicker.WidgetKey,
-                TimePicker.SelectedTimeChanged.WithValue(ValueEventData.create time fn)
-            )
+            WidgetBuilder<'msg, IFabTimePicker>(TimePicker.WidgetKey, TimePicker.SelectedTimeChanged.WithValue(ValueEventData.create time fn))
 
 [<Extension>]
 type TimePickerModifiers =

--- a/src/Fabulous.Avalonia/Views/Controls/TimePicker.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/TimePicker.fs
@@ -30,7 +30,7 @@ module TimePickerBuilders =
         static member inline TimePicker(time: TimeSpan, fn: TimeSpan -> 'msg) =
             WidgetBuilder<'msg, IFabTimePicker>(
                 TimePicker.WidgetKey,
-                TimePicker.SelectedTimeChanged.WithValue(ValueEventData.create time (fun args -> fn args |> box))
+                TimePicker.SelectedTimeChanged.WithValue(ValueEventData.create time fn)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/ToggleSwitch.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/ToggleSwitch.fs
@@ -46,7 +46,7 @@ module ToggleSwitchBuilders =
             WidgetBuilder<'msg, IFabToggleSwitch>(
                 ToggleSwitch.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(false),
-                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked (fun args -> fn args |> box))
+                ToggleButton.CheckedChanged.WithValue(ValueEventData.create isChecked fn)
             )
 
         /// <summary>Creates a ThreeStateToggleSwitch widget.</summary>
@@ -57,7 +57,7 @@ module ToggleSwitchBuilders =
                 ToggleSwitch.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(true),
                 ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (fun args -> fn(ThreeState.toOption args) |> box)
+                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
                 )
             )
 

--- a/src/Fabulous.Avalonia/Views/Controls/ToggleSwitch.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/ToggleSwitch.fs
@@ -56,9 +56,7 @@ module ToggleSwitchBuilders =
             WidgetBuilder<'msg, IFabToggleSwitch>(
                 ToggleSwitch.WidgetKey,
                 ToggleButton.IsThreeState.WithValue(true),
-                ToggleButton.ThreeStateCheckedChanged.WithValue(
-                    ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn)
-                )
+                ToggleButton.ThreeStateCheckedChanged.WithValue(ValueEventData.createVOption (ThreeState.fromOption(isChecked)) (ThreeState.toOption >> fn))
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/Controls/Window.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Window.fs
@@ -158,21 +158,21 @@ type WindowModifiers =
     /// <param name="fn">Raised when the window is closing.</param>
     [<Extension>]
     static member inline onWindowClosing(this: WidgetBuilder<'msg, #IFabWindow>, fn: WindowClosingEventArgs -> 'msg) =
-        this.AddScalar(Window.WindowClosing.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Window.WindowClosing.WithValue(fn))
 
     /// <summary>Listens to the Window WindowClosed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the window is closed.</param>
     [<Extension>]
     static member inline onWindowClosed(this: WidgetBuilder<'msg, #IFabWindow>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(Window.WindowClosed.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Window.WindowClosed.WithValue(fn))
 
     /// <summary>Listens to the Window WindowOpened event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the window is opened.</param>
     [<Extension>]
     static member inline onWindowOpened(this: WidgetBuilder<'msg, #IFabWindow>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(Window.WindowOpened.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Window.WindowOpened.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct Window control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Imaging/TrayIcon.fs
+++ b/src/Fabulous.Avalonia/Views/Imaging/TrayIcon.fs
@@ -59,10 +59,10 @@ type TrayIconModifiers =
 
     /// <summary>Listens to the TrayIcon Clicked event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Clicked event fires.</param>
+    /// <param name="msg">Raised when the Clicked event fires.</param>
     [<Extension>]
-    static member inline onClicked(this: WidgetBuilder<'msg, #IFabTrayIcon>, fn: 'msg) =
-        this.AddScalar(TrayIcon.Clicked.WithValue(fun _ -> fn |> box))
+    static member inline onClicked(this: WidgetBuilder<'msg, #IFabTrayIcon>, msg: 'msg) =
+        this.AddScalar(TrayIcon.Clicked.WithValue(MsgValue msg))
 
     /// <summary>Link a ViewRef to access the direct TrayIcon control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Layouts/ScrollViewer.fs
+++ b/src/Fabulous.Avalonia/Views/Layouts/ScrollViewer.fs
@@ -148,7 +148,7 @@ type ScrollViewerModifiers =
     /// <param name="fn">Raised when the ScrollChanged event fires.</param>
     [<Extension>]
     static member inline onScrollChanged(this: WidgetBuilder<'msg, #IFabScrollViewer>, fn: ScrollChangedEventArgs -> 'msg) =
-        this.AddScalar(ScrollViewer.ScrollChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ScrollViewer.ScrollChanged.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct ScrollViewer control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Layouts/SliptView.fs
+++ b/src/Fabulous.Avalonia/Views/Layouts/SliptView.fs
@@ -166,28 +166,28 @@ type SplitViewModifiers =
     /// <param name="fn">Raised when the PanClosed event fires.</param>
     [<Extension>]
     static member inline onPanClosed(this: WidgetBuilder<'msg, #IFabSplitView>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(SplitView.PanClosed.WithValue(fun args -> fn args |> box))
+        this.AddScalar(SplitView.PanClosed.WithValue(fn))
 
     /// <summary>Listens to the SplitView PanClosing event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the PanClosing event fires.</param>
     [<Extension>]
     static member inline onPanClosing(this: WidgetBuilder<'msg, #IFabSplitView>, fn: CancelRoutedEventArgs -> 'msg) =
-        this.AddScalar(SplitView.PanClosing.WithValue(fun args -> fn args |> box))
+        this.AddScalar(SplitView.PanClosing.WithValue(fn))
 
     /// <summary>Listens to the SplitView PanOpened event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the PanOpened event fires.</param>
     [<Extension>]
     static member inline onPanOpened(this: WidgetBuilder<'msg, #IFabSplitView>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(SplitView.PanOpened.WithValue(fun args -> fn args |> box))
+        this.AddScalar(SplitView.PanOpened.WithValue(fn))
 
     /// <summary>Listens to the SplitView PanOpening event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the PanOpening event fires.</param>
     [<Extension>]
     static member inline onPanOpening(this: WidgetBuilder<'msg, #IFabSplitView>, fn: CancelRoutedEventArgs -> 'msg) =
-        this.AddScalar(SplitView.PanOpening.WithValue(fun args -> fn args |> box))
+        this.AddScalar(SplitView.PanOpening.WithValue(fn))
 
     /// <summary>Listens to the SplitView IsPresented event.</summary>
     /// <param name="this">Current widget.</param>
@@ -195,7 +195,7 @@ type SplitViewModifiers =
     /// <param name="fn">Raised when the IsPresented event fires.</param>
     [<Extension>]
     static member inline isPresented(this: WidgetBuilder<'msg, #IFabSplitView>, value: bool, fn: bool -> 'msg) =
-        this.AddScalar(SplitView.IsPresented.WithValue(ValueEventData.create value (fun v -> fn v |> box)))
+        this.AddScalar(SplitView.IsPresented.WithValue(ValueEventData.create value fn))
 
     /// <summary>Link a ViewRef to access the direct SplitView control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Media/Drawing/DrawingImage.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Drawing/DrawingImage.fs
@@ -32,7 +32,7 @@ module DrawingImageBuilders =
 type DrawingImageModifiers =
     /// <summary>Listens the DrawingImage Invalidated event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the DrawingImage is invalidated.</param>
+    /// <param name="msg">Raised when the DrawingImage is invalidated.</param>
     [<Extension>]
-    static member inline onInvalidated(this: WidgetBuilder<'msg, #IFabDrawingImage>, fn: 'msg) =
-        this.AddScalar(DrawingImage.Invalidated.WithValue(fun _ -> fn |> box))
+    static member inline onInvalidated(this: WidgetBuilder<'msg, #IFabDrawingImage>, msg: 'msg) =
+        this.AddScalar(DrawingImage.Invalidated.WithValue(MsgValue msg))

--- a/src/Fabulous.Avalonia/Views/Media/Effects/_Effect.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Effects/_Effect.fs
@@ -15,10 +15,10 @@ module Effect =
 type EffectModifiers =
     /// <summary>Listens the Effect Invalidated event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Effect is invalidated.</param>
+    /// <param name="msg">Raised when the Effect is invalidated.</param>
     [<Extension>]
-    static member inline onInvalidated(this: WidgetBuilder<'msg, #IFabEffect>, fn: 'msg) =
-        this.AddScalar(Effect.Invalidated.WithValue(fun _ -> fn |> box))
+    static member inline onInvalidated(this: WidgetBuilder<'msg, #IFabEffect>, msg: 'msg) =
+        this.AddScalar(Effect.Invalidated.WithValue(MsgValue msg))
 
 [<Extension>]
 type AttachedEffectModifiers =

--- a/src/Fabulous.Avalonia/Views/Media/Geometries/_IGeometry.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Geometries/_IGeometry.fs
@@ -22,7 +22,7 @@ type GeometryModifiers =
 
     /// <summary>Listens to the Geometry Changed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the geometry changes.</param>
+    /// <param name="msg">Raised when the geometry changes.</param>
     [<Extension>]
-    static member inline onChanged(this: WidgetBuilder<'msg, #IFabGeometry>, fn: 'msg) =
-        this.AddScalar(Geometry.Changed.WithValue(fun _ -> fn |> box))
+    static member inline onChanged(this: WidgetBuilder<'msg, #IFabGeometry>, msg: 'msg) =
+        this.AddScalar(Geometry.Changed.WithValue(MsgValue msg))

--- a/src/Fabulous.Avalonia/Views/Media/Transforms/Rotate3DTransform.fs
+++ b/src/Fabulous.Avalonia/Views/Media/Transforms/Rotate3DTransform.fs
@@ -59,7 +59,7 @@ module Rotate3DTransformBuilders =
         static member Rotate3DTransform(angleX: float, angleY: float, angleZ: float, centerX: float, centerY: float, centerZ: float, depth: float) =
             WidgetBuilder<'msg, IFabRotate3DTransform>(
                 Rotate3DTransform.WidgetKey,
-                Rotate3DTransform.Angle.WithValue(angleX, angleY, angleZ),
-                Rotate3DTransform.Center.WithValue(centerX, centerY, centerZ),
+                Rotate3DTransform.Angle.WithValue(struct (angleX, angleY, angleZ)),
+                Rotate3DTransform.Center.WithValue(struct (centerX, centerY, centerZ)),
                 Rotate3DTransform.Depth.WithValue(depth)
             )

--- a/src/Fabulous.Avalonia/Views/Menu/ComboBox.fs
+++ b/src/Fabulous.Avalonia/Views/Menu/ComboBox.fs
@@ -116,7 +116,7 @@ type ComboBoxModifiers =
     /// <param name="fn">Raised when the DropDownOpened event fires.</param>
     [<Extension>]
     static member inline onDropDownOpened(this: WidgetBuilder<'msg, #IFabComboBox>, isOpen: bool, fn: bool -> 'msg) =
-        this.AddScalar(ComboBox.DropDownOpened.WithValue(ValueEventData.create isOpen (fun args -> fn args |> box)))
+        this.AddScalar(ComboBox.DropDownOpened.WithValue(ValueEventData.create isOpen fn))
 
     /// <summary>Link a ViewRef to access the direct ComboBox control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Menu/ContextMenu.fs
+++ b/src/Fabulous.Avalonia/Views/Menu/ContextMenu.fs
@@ -121,14 +121,14 @@ type ContextMenuModifiers =
     /// <param name="fn">Raised when the Opening event fires.</param>
     [<Extension>]
     static member inline onOpening(this: WidgetBuilder<'msg, #IFabContextMenu>, fn: CancelEventArgs -> 'msg) =
-        this.AddScalar(ContextMenu.Opening.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ContextMenu.Opening.WithValue(fn))
 
     /// <summary>Listens to the ContextMenu Closing event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the Closing event fires.</param>
     [<Extension>]
     static member inline onClosing(this: WidgetBuilder<'msg, #IFabContextMenu>, fn: CancelEventArgs -> 'msg) =
-        this.AddScalar(ContextMenu.Closing.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ContextMenu.Closing.WithValue(fn))
 
     /// <summary>Sets the PlacementTarget property.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Menu/NativeMenu.fs
+++ b/src/Fabulous.Avalonia/Views/Menu/NativeMenu.fs
@@ -38,24 +38,24 @@ module NativeMenuBuilders =
 type NativeMenuModifiers =
     /// <summary>Listens to the NativeMenu Opening event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Opening event fires.</param>
+    /// <param name="msg">Raised when the Opening event fires.</param>
     [<Extension>]
-    static member inline onOpening(this: WidgetBuilder<'msg, #IFabNativeMenu>, fn: 'msg) =
-        this.AddScalar(NativeMenu.Opening.WithValue(fun _ -> fn |> box))
+    static member inline onOpening(this: WidgetBuilder<'msg, #IFabNativeMenu>, msg: 'msg) =
+        this.AddScalar(NativeMenu.Opening.WithValue(fun _ -> box msg))
 
     /// <summary>Listens to the NativeMenu Closed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Closed event fires.</param>
+    /// <param name="msg">Raised when the Closed event fires.</param>
     [<Extension>]
-    static member inline onClosed(this: WidgetBuilder<'msg, #IFabNativeMenu>, fn: 'msg) =
-        this.AddScalar(NativeMenu.Closed.WithValue(fun _ -> fn |> box))
+    static member inline onClosed(this: WidgetBuilder<'msg, #IFabNativeMenu>, msg: 'msg) =
+        this.AddScalar(NativeMenu.Closed.WithValue(fun _ -> box msg))
 
     /// <summary>Listens to the NativeMenu NeedsUpdate event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the NeedsUpdate event fires.</param>
+    /// <param name="msg">Raised when the NeedsUpdate event fires.</param>
     [<Extension>]
-    static member inline onNeedsUpdate(this: WidgetBuilder<'msg, #IFabNativeMenu>, fn: 'msg) =
-        this.AddScalar(NativeMenu.NeedsUpdate.WithValue(fun _ -> fn |> box))
+    static member inline onNeedsUpdate(this: WidgetBuilder<'msg, #IFabNativeMenu>, msg: 'msg) =
+        this.AddScalar(NativeMenu.NeedsUpdate.WithValue(fun _ -> box msg))
 
     /// <summary>Link a ViewRef to access the direct NativeMenu control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Menu/NativeMenuItem.fs
+++ b/src/Fabulous.Avalonia/Views/Menu/NativeMenuItem.fs
@@ -53,7 +53,7 @@ module NativeMenuItemBuilders =
             WidgetBuilder<'msg, IFabNativeMenuItem>(
                 NativeMenuItem.WidgetKey,
                 NativeMenuItem.Header.WithValue(header),
-                NativeMenuItem.Click.WithValue(onClicked)
+                NativeMenuItem.Click.WithValue(MsgValue onClicked)
             )
 
 [<Extension>]

--- a/src/Fabulous.Avalonia/Views/MenuItems/MenuItem.fs
+++ b/src/Fabulous.Avalonia/Views/MenuItems/MenuItem.fs
@@ -59,7 +59,7 @@ module MenuItemBuilders =
             WidgetBuilder<'msg, IFabMenuItem>(
                 MenuItem.WidgetKey,
                 HeaderedContentControl.HeaderString.WithValue(header),
-                MenuItem.Clicked.WithValue(fun _ -> onClick |> box)
+                MenuItem.Clicked.WithValue(fun _ -> box onClick)
             )
 
         /// <summary>Creates a MenuItem widget.</summary>
@@ -77,7 +77,7 @@ module MenuItemBuilders =
             WidgetBuilder<'msg, IFabMenuItem>(
                 MenuItem.WidgetKey,
                 AttributesBundle(
-                    StackList.one(MenuItem.Clicked.WithValue(fun _ -> onClick |> box)),
+                    StackList.one(MenuItem.Clicked.WithValue(fun _ -> box onClick)),
                     ValueSome [| HeaderedContentControl.HeaderWidget.WithValue(header.Compile()) |],
                     ValueNone
                 )
@@ -101,7 +101,7 @@ module MenuItemBuilders =
                 MenuItem.WidgetKey,
                 ItemsControl.Items,
                 HeaderedContentControl.HeaderString.WithValue(header),
-                MenuItem.Clicked.WithValue(fun _ -> onClick |> box)
+                MenuItem.Clicked.WithValue(fun _ -> box onClick)
             )
 
         /// <summary>Creates a MenuItems widget.</summary>
@@ -118,7 +118,7 @@ module MenuItemBuilders =
         static member inline MenuItems(header: WidgetBuilder<'msg, #IFabMenuItem>, onClick: 'msg) =
             WidgetHelpers.buildWidgets<'msg, #IFabMenuItem>
                 MenuItem.WidgetKey
-                (StackList.one(MenuItem.Clicked.WithValue(fun _ -> onClick |> box)))
+                (StackList.one(MenuItem.Clicked.WithValue(fun _ -> box onClick)))
                 [| HeaderedContentControl.HeaderWidget.WithValue(header.Compile()) |]
 
 [<Extension>]
@@ -170,21 +170,21 @@ type MenuItemModifiers =
     /// <param name="fn">Raised when the PointerEnteredItem event is fired.</param>
     [<Extension>]
     static member inline onPointerEnteredItem(this: WidgetBuilder<'msg, #IFabMenuItem>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(MenuItem.PointerEnteredItem.WithValue(fun args -> fn args |> box))
+        this.AddScalar(MenuItem.PointerEnteredItem.WithValue(fn))
 
     /// <summary>Listens to the MenuItem PointerExitedItem event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the PointerExitedItem event is fired.</param>
     [<Extension>]
     static member inline onPointerExitedItem(this: WidgetBuilder<'msg, #IFabMenuItem>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(MenuItem.PointerExitedItem.WithValue(fun args -> fn args |> box))
+        this.AddScalar(MenuItem.PointerExitedItem.WithValue(fn))
 
     /// <summary>Listens to the MenuItem SubmenuClosed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the SubmenuClosed event is fired.</param>
     [<Extension>]
     static member inline onSubmenuOpened(this: WidgetBuilder<'msg, #IFabMenuItem>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(MenuItem.SubmenuOpened.WithValue(fun args -> fn args |> box))
+        this.AddScalar(MenuItem.SubmenuOpened.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct MenuItem control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/Panels/StackPanel.fs
+++ b/src/Fabulous.Avalonia/Views/Panels/StackPanel.fs
@@ -50,14 +50,14 @@ type StackPanelModifiers =
     /// <param name="fn">Raised when the HorizontalSnapPointsChanged event fires.</param>
     [<Extension>]
     static member inline onHorizontalSnapPointsChanged(this: WidgetBuilder<'msg, #IFabStackPanel>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(StackPanel.HorizontalSnapPointsChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(StackPanel.HorizontalSnapPointsChanged.WithValue(fn))
 
     /// <summary>Listens to the StackPanel VerticalSnapPointsChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the VerticalSnapPointsChanged event fires.</param>
     [<Extension>]
     static member inline onVerticalSnapPointsChanged(this: WidgetBuilder<'msg, #IFabStackPanel>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(StackPanel.VerticalSnapPointsChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(StackPanel.VerticalSnapPointsChanged.WithValue(fn))
 
     /// <summary>Link a ViewRef to access the direct StackPanel control instance.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/_Control.fs
+++ b/src/Fabulous.Avalonia/Views/_Control.fs
@@ -66,14 +66,14 @@ type ControlModifiers =
     /// <param name="fn">Raised when the user has completed a context input gesture, such as a right-click.</param>
     [<Extension>]
     static member inline onContextRequested(this: WidgetBuilder<'msg, #IFabControl>, fn: ContextRequestedEventArgs -> 'msg) =
-        this.AddScalar(Control.ContextRequested.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Control.ContextRequested.WithValue(fn))
 
     /// <summary>Listens to the Control RequestBringIntoView event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when an element wishes to be scrolled into view.</param>
     [<Extension>]
     static member inline onRequestBringIntoView(this: WidgetBuilder<'msg, #IFabControl>, fn: RequestBringIntoViewEventArgs -> 'msg) =
-        this.AddScalar(Control.RequestBringIntoView.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Control.RequestBringIntoView.WithValue(fn))
 
     /// <summary>Listens to the Control Loaded event.</summary>
     /// <param name="this">Current widget.</param>
@@ -81,18 +81,18 @@ type ControlModifiers =
     /// layout and render are complete.</param>
     [<Extension>]
     static member inline onLoaded(this: WidgetBuilder<'msg, #IFabControl>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(Control.Loaded.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Control.Loaded.WithValue(fn))
 
     /// <summary>Listens to the Control UnLoaded event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the control is removed from the visual tree.</param>
     [<Extension>]
     static member inline onUnLoaded(this: WidgetBuilder<'msg, #IFabControl>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(Control.UnLoaded.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Control.UnLoaded.WithValue(fn))
 
     /// <summary>Listens to the Control SizeChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the control's size changes.</param>
     [<Extension>]
     static member inline onSizeChanged(this: WidgetBuilder<'msg, #IFabControl>, fn: SizeChangedEventArgs -> 'msg) =
-        this.AddScalar(Control.SizeChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Control.SizeChanged.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/_DragDrop.fs
+++ b/src/Fabulous.Avalonia/Views/_DragDrop.fs
@@ -28,28 +28,28 @@ type DragDropModifiers =
     /// <param name="fn">Raised when a drag-and-drop operation enters the element.</param>
     [<Extension>]
     static member inline onDragEnter(this: WidgetBuilder<'msg, #IFabInteractive>, fn: DragEventArgs -> 'msg) =
-        this.AddScalar(DragDrop.DragEnter.WithValue(fun args -> fn args |> box))
+        this.AddScalar(DragDrop.DragEnter.WithValue(fn))
 
     /// <summary>Listens to the DragDrop DragLeave event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a drag-and-drop operation leaves the element.</param>
     [<Extension>]
     static member inline onDragLeave(this: WidgetBuilder<'msg, #IFabInteractive>, fn: DragEventArgs -> 'msg) =
-        this.AddScalar(DragDrop.DragLeave.WithValue(fun args -> fn args |> box))
+        this.AddScalar(DragDrop.DragLeave.WithValue(fn))
 
     /// <summary>Listens to the DragDrop DragOver event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a drag-and-drop operation is in progress over the element.</param>
     [<Extension>]
     static member inline onDragOver(this: WidgetBuilder<'msg, #IFabInteractive>, fn: DragEventArgs -> 'msg) =
-        this.AddScalar(DragDrop.DragOver.WithValue(fun args -> fn args |> box))
+        this.AddScalar(DragDrop.DragOver.WithValue(fn))
 
     /// <summary>Listens to the DragDrop Drop event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a drag-and-drop operation is dropped on the element.</param>
     [<Extension>]
     static member inline onDrop(this: WidgetBuilder<'msg, #IFabInteractive>, fn: DragEventArgs -> 'msg) =
-        this.AddScalar(DragDrop.Drop.WithValue(fun args -> fn args |> box))
+        this.AddScalar(DragDrop.Drop.WithValue(fn))
 
     /// <summary>Sets the AllowDrop property.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/_FlyoutBase.fs
+++ b/src/Fabulous.Avalonia/Views/_FlyoutBase.fs
@@ -24,17 +24,17 @@ module FlyoutBase =
 type FlyoutBaseModifiers =
     /// <summary>Listens to the FlyoutBase Opened event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the FlyoutBase is opened.</param>
+    /// <param name="msg">Raised when the FlyoutBase is opened.</param>
     [<Extension>]
-    static member inline onOpened(this: WidgetBuilder<'msg, #IFabFlyoutBase>, fn: 'msg) =
-        this.AddScalar(FlyoutBase.Opened.WithValue(fun _ -> fn |> box))
+    static member inline onOpened(this: WidgetBuilder<'msg, #IFabFlyoutBase>, msg: 'msg) =
+        this.AddScalar(FlyoutBase.Opened.WithValue(MsgValue msg))
 
     /// <summary>Listens to the FlyoutBase Closed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the FlyoutBase is closed.</param>
+    /// <param name="msg">Raised when the FlyoutBase is closed.</param>
     [<Extension>]
-    static member inline onClosed(this: WidgetBuilder<'msg, #IFabFlyoutBase>, fn: 'msg) =
-        this.AddScalar(FlyoutBase.Closed.WithValue(fun _ -> fn |> box))
+    static member inline onClosed(this: WidgetBuilder<'msg, #IFabFlyoutBase>, msg: 'msg) =
+        this.AddScalar(FlyoutBase.Closed.WithValue(MsgValue msg))
 
     /// <summary>Sets the Target property.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/_ITransform.fs
+++ b/src/Fabulous.Avalonia/Views/_ITransform.fs
@@ -16,7 +16,7 @@ module Transform =
 type TransformModifiers =
     /// <summary>Listens to the Transform changed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the Transform changes.</param>
+    /// <param name="msg">Raised when the Transform changes.</param>
     [<Extension>]
-    static member inline onChanged(this: WidgetBuilder<'msg, #IFabTransform>, fn: 'msg) =
-        this.AddScalar(Transform.Changed.WithValue(fun _ -> fn |> box))
+    static member inline onChanged(this: WidgetBuilder<'msg, #IFabTransform>, msg: 'msg) =
+        this.AddScalar(Transform.Changed.WithValue(MsgValue msg))

--- a/src/Fabulous.Avalonia/Views/_InputElement.fs
+++ b/src/Fabulous.Avalonia/Views/_InputElement.fs
@@ -127,109 +127,109 @@ type InputElementModifiers =
     /// <param name="fn">Raised when control receives focus.</param>
     [<Extension>]
     static member inline onGotFocus(this: WidgetBuilder<'msg, #IFabInputElement>, fn: GotFocusEventArgs -> 'msg) =
-        this.AddScalar(InputElement.GotFocus.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.GotFocus.WithValue(fn))
 
     /// <summary>Listens to the InputElement LostFocus event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when control loses focus.</param>
     [<Extension>]
     static member inline onLostFocus(this: WidgetBuilder<'msg, #IFabInputElement>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.LostFocus.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.LostFocus.WithValue(fn))
 
     /// <summary>Listens to the InputElement KeyDown event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a key is pressed while the control has focus.</param>
     [<Extension>]
     static member inline onKeyDown(this: WidgetBuilder<'msg, #IFabInputElement>, fn: KeyEventArgs -> 'msg) =
-        this.AddScalar(InputElement.KeyDown.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.KeyDown.WithValue(fn))
 
     /// <summary>Listens to the InputElement KeyUp event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a key is released while the control has focus.</param>
     [<Extension>]
     static member inline onKeyUp(this: WidgetBuilder<'msg, #IFabInputElement>, fn: KeyEventArgs -> 'msg) =
-        this.AddScalar(InputElement.KeyUp.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.KeyUp.WithValue(fn))
 
     /// <summary>Listens to the InputElement TextInput event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a user typed some text while the control has focus.</param>
     [<Extension>]
     static member inline onTextInput(this: WidgetBuilder<'msg, #IFabInputElement>, fn: TextInputEventArgs -> 'msg) =
-        this.AddScalar(InputElement.TextInput.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.TextInput.WithValue(fn))
 
     /// <summary>Listens to the InputElement TextInputMethodClientRequested event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when an input element gains input focus and input method is looking for the corresponding client.</param>
     [<Extension>]
     static member inline onTextInputMethodClientRequested(this: WidgetBuilder<'msg, #IFabInputElement>, fn: TextInputMethodClientRequestedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.TextInputMethodClientRequested.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.TextInputMethodClientRequested.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerEntered event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when pointer enters the control.</param>
     [<Extension>]
     static member inline onPointerEntered(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerEntered.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerEntered.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerExited event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when pointer leaves the control.</param>
     [<Extension>]
     static member inline onPointerExited(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerExited.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerExited.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerMoved event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when pointer moves over the control.</param>
     [<Extension>]
     static member inline onPointerMoved(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerMoved.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerMoved.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerPressed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the pointer is pressed over the control.</param>
     [<Extension>]
     static member inline onPointerPressed(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerPressedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerPressed.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerPressed.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerReleased event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the pointer is released over the control.</param>
     [<Extension>]
     static member inline onPointerReleased(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerReleasedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerReleased.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerReleased.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerCaptureLost event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when he control or its child control loses the pointer capture for any reason event will not be triggered for a parent control if capture was transferred to another child of that parent control.</param>
     [<Extension>]
     static member inline onPointerCaptureLost(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerCaptureLostEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerCaptureLost.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerCaptureLost.WithValue(fn))
 
     /// <summary>Listens to the InputElement PointerWheelChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the pointer wheel changes.</param>
     [<Extension>]
     static member inline onPointerWheelChanged(this: WidgetBuilder<'msg, #IFabInputElement>, fn: PointerWheelEventArgs -> 'msg) =
-        this.AddScalar(InputElement.PointerWheelChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.PointerWheelChanged.WithValue(fn))
 
     /// <summary>Listens to the InputElement Tapped event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a tap gesture occurs on the control.</param>
     [<Extension>]
     static member inline onTapped(this: WidgetBuilder<'msg, #IFabInputElement>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.Tapped.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.Tapped.WithValue(fn))
 
     /// <summary>Listens to the InputElement Holding event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a holding gesture occurs on the control.</param>
     [<Extension>]
     static member inline onHolding(this: WidgetBuilder<'msg, #IFabInputElement>, fn: HoldingRoutedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.Holding.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.Holding.WithValue(fn))
 
     /// <summary>Listens to the InputElement RightTapped event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a double-tap gesture occurs on the control.</param>
     [<Extension>]
     static member inline onDoubleTapped(this: WidgetBuilder<'msg, #IFabInputElement>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(InputElement.DoubleTapped.WithValue(fun args -> fn args |> box))
+        this.AddScalar(InputElement.DoubleTapped.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/_ItemsControl.fs
+++ b/src/Fabulous.Avalonia/Views/_ItemsControl.fs
@@ -67,18 +67,18 @@ type ItemsControlModifiers =
     /// <param name="fn">Raised when the actual theme variant changes.</param>
     [<Extension>]
     static member inline onContainerClearing(this: WidgetBuilder<'msg, #IFabItemsControl>, fn: ContainerClearingEventArgs -> 'msg) =
-        this.AddScalar(ItemsControl.ContainerClearing.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ItemsControl.ContainerClearing.WithValue(fn))
 
     /// <summary>Listens to the ItemsControl ContainerIndexChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the index for the item it represents has changed.</param>
     [<Extension>]
     static member inline onContainerIndexChanged(this: WidgetBuilder<'msg, #IFabItemsControl>, fn: ContainerIndexChangedEventArgs -> 'msg) =
-        this.AddScalar(ItemsControl.ContainerIndexChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ItemsControl.ContainerIndexChanged.WithValue(fn))
 
     /// <summary>Listens to the ItemsControl ContainerPrepared event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when a container is prepared for use.</param>
     [<Extension>]
     static member inline onContainerPrepared(this: WidgetBuilder<'msg, #IFabItemsControl>, fn: ContainerPreparedEventArgs -> 'msg) =
-        this.AddScalar(ItemsControl.ContainerPrepared.WithValue(fun args -> fn args |> box))
+        this.AddScalar(ItemsControl.ContainerPrepared.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/_Layoutable.fs
+++ b/src/Fabulous.Avalonia/Views/_Layoutable.fs
@@ -120,14 +120,14 @@ type LayoutableModifiers =
     /// <param name="fn">Raised when the element's effective viewport changes.</param>
     [<Extension>]
     static member inline onEffectiveViewportChanged(this: WidgetBuilder<'msg, #IFabLayoutable>, fn: EffectiveViewportChangedEventArgs -> 'msg) =
-        this.AddScalar(Layoutable.EffectiveViewportChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Layoutable.EffectiveViewportChanged.WithValue(fn))
 
     /// <summary>Listens to the Layoutable LayoutUpdated event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the element's layout is updated.</param>
+    /// <param name="msg">Raised when the element's layout is updated.</param>
     [<Extension>]
-    static member inline onLayoutUpdated(this: WidgetBuilder<'msg, #IFabLayoutable>, fn: 'msg) =
-        this.AddScalar(Layoutable.LayoutUpdated.WithValue(fn))
+    static member inline onLayoutUpdated(this: WidgetBuilder<'msg, #IFabLayoutable>, msg: 'msg) =
+        this.AddScalar(Layoutable.LayoutUpdated.WithValue(MsgValue msg))
 
 [<Extension>]
 type LayoutableExtraModifiers =

--- a/src/Fabulous.Avalonia/Views/_MenuBase.fs
+++ b/src/Fabulous.Avalonia/Views/_MenuBase.fs
@@ -22,11 +22,11 @@ type MenuBaseModifiers =
     /// <param name="fn">Raised when the Menu is opened.</param>
     [<Extension>]
     static member inline onOpened(this: WidgetBuilder<'msg, #IFabMenuBase>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(MenuBase.Opened.WithValue(fun args -> fn args |> box))
+        this.AddScalar(MenuBase.Opened.WithValue(fn))
 
     /// <summary>Listens to the MenuClosed event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the Menu is closed.</param>
     [<Extension>]
     static member inline onClosed(this: WidgetBuilder<'msg, #IFabMenuBase>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(MenuBase.Closed.WithValue(fun args -> fn args |> box))
+        this.AddScalar(MenuBase.Closed.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/_PopupFlyoutBase.fs
+++ b/src/Fabulous.Avalonia/Views/_PopupFlyoutBase.fs
@@ -92,14 +92,14 @@ type PopupFlyoutBaseModifiers =
 
     /// <summary>Listens to the PopupFlyoutBase Opening event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the PopupFlyoutBase is opening.</param>
+    /// <param name="msg">Raised when the PopupFlyoutBase is opening.</param>
     [<Extension>]
-    static member inline onOpening(this: WidgetBuilder<'msg, #IFabPopupFlyoutBase>, fn: 'msg) =
-        this.AddScalar(PopupFlyoutBase.Opening.WithValue(fun _ -> fn |> box))
+    static member inline onOpening(this: WidgetBuilder<'msg, #IFabPopupFlyoutBase>, msg: 'msg) =
+        this.AddScalar(PopupFlyoutBase.Opening.WithValue(MsgValue msg))
 
     /// <summary>Listens to the PopupFlyoutBase Closing event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the PopupFlyoutBase is closing.</param>
     [<Extension>]
     static member inline onClosing(this: WidgetBuilder<'msg, #IFabPopupFlyoutBase>, fn: CancelEventArgs -> 'msg) =
-        this.AddScalar(PopupFlyoutBase.Closing.WithValue(fun args -> fn args |> box))
+        this.AddScalar(PopupFlyoutBase.Closing.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/_SelectingItemsControl.fs
+++ b/src/Fabulous.Avalonia/Views/_SelectingItemsControl.fs
@@ -73,11 +73,12 @@ type SelectingItemsControlModifiers =
     /// <param name="fn">Raised when the control's selection changes.</param>
     [<Extension>]
     static member inline onSelectionChanged(this: WidgetBuilder<'msg, #IFabSelectingItemsControl>, fn: SelectionChangedEventArgs -> 'msg) =
-        this.AddScalar(SelectingItemsControl.SelectionChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(SelectingItemsControl.SelectionChanged.WithValue(fn))
 
     /// <summary>Listens to the SelectingItemsControl SelectedIndexChanged event.</summary>
     /// <param name="this">Current widget.</param>
+    /// <param name="index">Selected index</param>
     /// <param name="fn">Raised when the control's selected index changes.</param>
     [<Extension>]
     static member inline onSelectedIndexChanged(this: WidgetBuilder<'msg, #IFabSelectingItemsControl>, index: int, fn: int -> 'msg) =
-        this.AddScalar(SelectingItemsControl.SelectedIndexChanged.WithValue(ValueEventData.create index (fun args -> fn args |> box)))
+        this.AddScalar(SelectingItemsControl.SelectedIndexChanged.WithValue(ValueEventData.create index fn))

--- a/src/Fabulous.Avalonia/Views/_StyledElement.fs
+++ b/src/Fabulous.Avalonia/Views/_StyledElement.fs
@@ -47,21 +47,21 @@ type StyledElementModifiers =
     /// <param name="fn">Raised when the styled element is attached to a rooted logical tree.</param>
     [<Extension>]
     static member inline onAttachedToLogicalTree(this: WidgetBuilder<'msg, #IFabStyledElement>, fn: LogicalTreeAttachmentEventArgs -> 'msg) =
-        this.AddScalar(StyledElement.AttachedToLogicalTree.WithValue(fun args -> fn args |> box))
+        this.AddScalar(StyledElement.AttachedToLogicalTree.WithValue(fn))
 
     /// <summary>Listens to the StyledElement DetachedFromLogicalTree event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the styled element is detached from a rooted logical tree.</param>
     [<Extension>]
     static member inline onDetachedFromLogicalTree(this: WidgetBuilder<'msg, #IFabStyledElement>, fn: LogicalTreeAttachmentEventArgs -> 'msg) =
-        this.AddScalar(StyledElement.DetachedFromLogicalTree.WithValue(fun args -> fn args |> box))
+        this.AddScalar(StyledElement.DetachedFromLogicalTree.WithValue(fn))
 
     /// <summary>Listens to the StyledElement ActualThemeVariantChanged event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the actual theme variant changes.</param>
+    /// <param name="msg">Raised when the actual theme variant changes.</param>
     [<Extension>]
-    static member inline onActualThemeVariantChanged(this: WidgetBuilder<'msg, #IFabStyledElement>, fn: 'msg) =
-        this.AddScalar(StyledElement.ActualThemeVariantChanged.WithValue(fun _ -> fn |> box))
+    static member inline onActualThemeVariantChanged(this: WidgetBuilder<'msg, #IFabStyledElement>, msg: 'msg) =
+        this.AddScalar(StyledElement.ActualThemeVariantChanged.WithValue(MsgValue msg))
 
 [<Extension>]
 type StyledElementCollectionBuilderExtensions =

--- a/src/Fabulous.Avalonia/Views/_TopLevel.fs
+++ b/src/Fabulous.Avalonia/Views/_TopLevel.fs
@@ -71,7 +71,7 @@ type TopLevelModifiers =
     /// <param name="fn">Raised when the actual theme variant changes.</param>
     [<Extension>]
     static member inline onThemeVariantChanged(this: WidgetBuilder<'msg, #IFabTopLevel>, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(TopLevel.ThemeVariantChanged.WithValue(MsgValue (fn Application.Current.ActualThemeVariant)))
+        this.AddScalar(TopLevel.ThemeVariantChanged.WithValue(MsgValue(fn Application.Current.ActualThemeVariant)))
 
     /// <summary>Sets the TransparencyLevelHint property.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Views/_TopLevel.fs
+++ b/src/Fabulous.Avalonia/Views/_TopLevel.fs
@@ -71,7 +71,7 @@ type TopLevelModifiers =
     /// <param name="fn">Raised when the actual theme variant changes.</param>
     [<Extension>]
     static member inline onThemeVariantChanged(this: WidgetBuilder<'msg, #IFabTopLevel>, fn: ThemeVariant -> 'msg) =
-        this.AddScalar(TopLevel.ThemeVariantChanged.WithValue(fn Application.Current.ActualThemeVariant))
+        this.AddScalar(TopLevel.ThemeVariantChanged.WithValue(MsgValue (fn Application.Current.ActualThemeVariant)))
 
     /// <summary>Sets the TransparencyLevelHint property.</summary>
     /// <param name="this">Current widget.</param>
@@ -117,28 +117,28 @@ type TopLevelModifiers =
 
     /// <summary>Listens the TopLevel Opened event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the window is opened.</param>
+    /// <param name="msg">Raised when the window is opened.</param>
     [<Extension>]
-    static member inline onOpened(this: WidgetBuilder<'msg, #IFabTopLevel>, fn: 'msg) =
-        this.AddScalar(TopLevel.Opened.WithValue(fun _ -> fn |> box))
+    static member inline onOpened(this: WidgetBuilder<'msg, #IFabTopLevel>, msg: 'msg) =
+        this.AddScalar(TopLevel.Opened.WithValue(MsgValue msg))
 
     /// <summary>Listens the TopLevel Closed event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the window is closed.</param>
+    /// <param name="msg">Raised when the window is closed.</param>
     [<Extension>]
-    static member inline onClosed(this: WidgetBuilder<'msg, #IFabTopLevel>, fn: 'msg) =
-        this.AddScalar(TopLevel.Closed.WithValue(fun _ -> fn |> box))
+    static member inline onClosed(this: WidgetBuilder<'msg, #IFabTopLevel>, msg: 'msg) =
+        this.AddScalar(TopLevel.Closed.WithValue(MsgValue msg))
 
     /// <summary>Listens the TopLevel BackRequested event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the back button is pressed.</param>
     [<Extension>]
     static member inline onBackRequested(this: WidgetBuilder<'msg, #IFabTopLevel>, fn: RoutedEventArgs -> 'msg) =
-        this.AddScalar(TopLevel.BackRequested.WithValue(fun args -> fn args |> box))
+        this.AddScalar(TopLevel.BackRequested.WithValue(fn))
 
     /// <summary>Listens the TopLevel ScalingChanged event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the TopLevel's scaling changes.</param>
+    /// <param name="msg">Raised when the TopLevel's scaling changes.</param>
     [<Extension>]
-    static member inline onScalingChanged(this: WidgetBuilder<'msg, #IFabTopLevel>, fn: 'msg) =
-        this.AddScalar(TopLevel.ScalingChanged.WithValue(fun _ -> fn |> box))
+    static member inline onScalingChanged(this: WidgetBuilder<'msg, #IFabTopLevel>, msg: 'msg) =
+        this.AddScalar(TopLevel.ScalingChanged.WithValue(MsgValue msg))

--- a/src/Fabulous.Avalonia/Views/_Visual.fs
+++ b/src/Fabulous.Avalonia/Views/_Visual.fs
@@ -141,11 +141,11 @@ type VisualModifiers =
     /// <param name="fn">Raised when the control is attached to a rooted visual tree.</param>
     [<Extension>]
     static member inline onAttachedToVisualTree(this: WidgetBuilder<'msg, #IFabVisual>, fn: VisualTreeAttachmentEventArgs -> 'msg) =
-        this.AddScalar(Visual.AttachedToVisualTree.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Visual.AttachedToVisualTree.WithValue(fn))
 
     /// <summary>Listens to the Visual DetachedFromVisualTree event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the control is detached from a rooted visual tree.</param>
     [<Extension>]
     static member inline onDetachedFromVisualTree(this: WidgetBuilder<'msg, #IFabVisual>, fn: VisualTreeAttachmentEventArgs -> 'msg) =
-        this.AddScalar(Visual.DetachedFromVisualTree.WithValue(fun args -> fn args |> box))
+        this.AddScalar(Visual.DetachedFromVisualTree.WithValue(fn))

--- a/src/Fabulous.Avalonia/Views/_WindowBase.fs
+++ b/src/Fabulous.Avalonia/Views/_WindowBase.fs
@@ -35,28 +35,28 @@ type WindowBaseModifiers =
 
     /// <summary>Listens to the WindowBase Activated event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the window is activated.</param>
+    /// <param name="msg">Raised when the window is activated.</param>
     [<Extension>]
-    static member inline onActivated(this: WidgetBuilder<'msg, #IFabWindowBase>, fn: 'msg) =
-        this.AddScalar(WindowBase.Activated.WithValue(fun _ -> fn |> box))
+    static member inline onActivated(this: WidgetBuilder<'msg, #IFabWindowBase>, msg: 'msg) =
+        this.AddScalar(WindowBase.Activated.WithValue(MsgValue msg))
 
     /// <summary>Listens to the WindowBase Deactivated event.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="fn">Raised when the window is deactivated.</param>
+    /// <param name="msg">Raised when the window is deactivated.</param>
     [<Extension>]
-    static member inline onDeactivated(this: WidgetBuilder<'msg, #IFabWindowBase>, fn: 'msg) =
-        this.AddScalar(WindowBase.Deactivated.WithValue(fun _ -> fn |> box))
+    static member inline onDeactivated(this: WidgetBuilder<'msg, #IFabWindowBase>, msg: 'msg) =
+        this.AddScalar(WindowBase.Deactivated.WithValue(MsgValue msg))
 
     /// <summary>Listens to the WindowBase PositionChanged event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the window position is changed.</param>
     [<Extension>]
     static member inline onPositionChanged(this: WidgetBuilder<'msg, #IFabWindowBase>, fn: PixelPointEventArgs -> 'msg) =
-        this.AddScalar(WindowBase.PositionChanged.WithValue(fun args -> fn args |> box))
+        this.AddScalar(WindowBase.PositionChanged.WithValue(fn))
 
     /// <summary>Listens to the WindowBase Resized event.</summary>
     /// <param name="this">Current widget.</param>
     /// <param name="fn">Raised when the window is resized.</param>
     [<Extension>]
     static member inline onResized(this: WidgetBuilder<'msg, #IFabWindowBase>, fn: WindowResizedEventArgs -> 'msg) =
-        this.AddScalar(WindowBase.Resized.WithValue(fun args -> fn args |> box))
+        this.AddScalar(WindowBase.Resized.WithValue(fn))

--- a/templates/content/blank/.template.config/template.json
+++ b/templates/content/blank/.template.config/template.json
@@ -44,7 +44,7 @@
       "type": "parameter",
       "dataType": "string",
       "replaces": "FabulousPkgVersion",
-      "defaultValue": "2.3.2"
+      "defaultValue": "2.4.0"
     },
     "FabulousAvaloniaPkgVersion": {
       "type": "parameter",


### PR DESCRIPTION
To help avoid crash in mapping to events, Fabulous now uses a specialized type instead of `obj` to store a message for event with no args.

Also changed `ValueEventData.create` and `ValueEventData.createVOption` to implicitly box the resulting message.

This PR requires us to first publish the change to Fabulous.