### PR TITLE
Fix Source Sans Pro font family reference in Gallery app TextBlock page.

### DIFF
--- a/samples/Gallery/Pages/TextBlockPage.fs
+++ b/samples/Gallery/Pages/TextBlockPage.fs
@@ -63,25 +63,26 @@ module TextBlockPage =
             )
                 .textWrapping(TextWrapping.Wrap)
 
+            let fontFamily = FontFamily("avares://Gallery/Assets/Fonts#Source Sans Pro")
             Border(
                 VStack(8.) {
                     TextBlock("Custom font regular")
-                        .fontFamily(FontFamily "SourceSansPro, Regular")
+                        .fontFamily(fontFamily)
                         .fontStyle(FontStyle.Normal)
                         .fontWeight(FontWeight.Normal)
 
                     TextBlock("Custom font bold")
-                        .fontFamily(FontFamily "SourceSansPro, Bold")
+                        .fontFamily(fontFamily)
                         .fontStyle(FontStyle.Normal)
                         .fontWeight(FontWeight.Bold)
 
                     TextBlock("Custom font italic")
-                        .fontFamily(FontFamily "SourceSansPro, Italic")
+                        .fontFamily(fontFamily)
                         .fontStyle(FontStyle.Italic)
                         .fontWeight(FontWeight.Normal)
 
                     TextBlock("Custom font italic bold")
-                        .fontFamily(FontFamily "SourceSansPro, Bold Italic")
+                        .fontFamily(fontFamily)
                         .fontStyle(FontStyle.Italic)
                         .fontWeight(FontWeight.Bold)
                 }

--- a/samples/Gallery/Pages/TextBlockPage.fs
+++ b/samples/Gallery/Pages/TextBlockPage.fs
@@ -64,6 +64,7 @@ module TextBlockPage =
                 .textWrapping(TextWrapping.Wrap)
 
             let fontFamily = FontFamily("avares://Gallery/Assets/Fonts#Source Sans Pro")
+
             Border(
                 VStack(8.) {
                     TextBlock("Custom font regular")


### PR DESCRIPTION
As I understand it the URI `avares://Gallery/Assets/Fonts#Source Sans Pro` determines the location of the embedded font family files and the name of the font family (as described in the font files) separated by the #.

The results don't look very different from the default font but they are, especially if the font size is increased.

Tested on Android and iOS.