### PR TITLE
Browser Template: Update path for JavaScript framework files for .Net 8.0

### DIFF
--- a/templates/content/multi/NewApp.Browser/AppBundle/index.html
+++ b/templates/content/multi/NewApp.Browser/AppBundle/index.html
@@ -8,8 +8,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="modulepreload" href="./main.js" />
-    <link rel="modulepreload" href="./dotnet.js" />
-    <link rel="modulepreload" href="./avalonia.js" />
+    <link rel="modulepreload" href="./_framework/dotnet.js" />
+    <link rel="modulepreload" href="./_framework/avalonia.js" />
     <link rel="stylesheet" href="./app.css" />
 </head>
 

--- a/templates/content/multi/NewApp.Browser/AppBundle/main.js
+++ b/templates/content/multi/NewApp.Browser/AppBundle/main.js
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { dotnet } from './dotnet.js'
+import { dotnet } from './_framework/dotnet.js'
 
 const is_browser = typeof window != "undefined";
 if (!is_browser) throw new Error(`Expected to be running in a browser`);


### PR DESCRIPTION
From .Net 8.0, Avalonia.Browser places .js framework files in './_framework/'

Note that Avalonia.Browser v.11.0.5 does not support .Net 8.0 (v.11.0.5 is the latest build on nuget.org as of 2023-12-03).
However, .Net 8.0 is supported in Avalonia.Browser v.11.1.999, available now on the AvaloniaUI nightly build package source (https://nuget-feed-nightly.avaloniaui.net/v3/index.json)