### PR TITLE
Fix for multi-proj template

### DIFF
--- a/templates/content/multi/NewApp.Browser/AppBundle/app.css
+++ b/templates/content/multi/NewApp.Browser/AppBundle/app.css
@@ -22,7 +22,7 @@
     background-repeat: no-repeat;
 }
 
-#avalonia-splash a{
+#avalonia-splash a {
     color: whitesmoke;
     text-decoration: none;
 }

--- a/templates/content/multi/NewApp.Browser/AppBundle/index.html
+++ b/templates/content/multi/NewApp.Browser/AppBundle/index.html
@@ -8,8 +8,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="modulepreload" href="./main.js" />
-    <link rel="modulepreload" href="./_framework/dotnet.js" />
-    <link rel="modulepreload" href="./_framework/avalonia.js" />
+    <link rel="modulepreload" href="./dotnet.js" />
+    <link rel="modulepreload" href="./avalonia.js" />
     <link rel="stylesheet" href="./app.css" />
 </head>
 

--- a/templates/content/multi/NewApp.Browser/AppBundle/main.js
+++ b/templates/content/multi/NewApp.Browser/AppBundle/main.js
@@ -1,7 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { dotnet } from './_framework/dotnet.js'
+import { dotnet } from './dotnet.js'
+// import { dotnet } from './_framework/dotnet.js' // NET8.0
 
 const is_browser = typeof window != "undefined";
 if (!is_browser) throw new Error(`Expected to be running in a browser`);
@@ -13,4 +14,4 @@ const dotnetRuntime = await dotnet
 
 const config = dotnetRuntime.getConfig();
 
-await dotnetRuntime.runMainAndExit(config.mainAssemblyName, ["dotnet", "is", "great!"]);
+await dotnetRuntime.runMainAndExit(config.mainAssemblyName, [globalThis.location.href]);


### PR DESCRIPTION
While https://github.com/fabulous-dev/Fabulous.Avalonia/pull/194 was the right fix for net8. It seems that Avalonia 11.0.6 did a workaround/hack to prevent users from having to change the paths.
