### PR TITLE
Sample of how to use the dispatch function handed to me by Cmd.ofEffect

### DIFF
--- a/samples/Gallery/Pages/CalendarPage.fs
+++ b/samples/Gallery/Pages/CalendarPage.fs
@@ -24,8 +24,8 @@ module CalendarPage =
 
     let update msg model =
         match msg with
-        | SelectedDateChanged dateTime -> { model with Date1 = dateTime }, []
-        | SelectedDatesChanged2 dateTime -> { model with Date2 = dateTime }, []
+        | SelectedDateChanged dateTime -> { model with Date1 = dateTime }, Cmd.none
+        | SelectedDatesChanged2 dateTime -> { model with Date2 = dateTime }, Cmd.none
 
     let startFromYesterday = DateTime.Today.Subtract(TimeSpan.FromDays(1.0))
 

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -2,15 +2,18 @@ namespace Gallery
 
 open System
 open System.Diagnostics
+open System.Threading
 open Avalonia
 open Avalonia.Controls.Notifications
 open Avalonia.Controls
 open Avalonia.Layout
 open Avalonia.Media
+open Avalonia.Threading
 open Fabulous
 open Fabulous.Avalonia
 
 open type Fabulous.Avalonia.View
+open Microsoft.FSharp.Control
 
 type NotificationViewModel(title, message) =
 
@@ -40,30 +43,41 @@ module NotificationsPage =
         | NoCommand
         | AttachedToVisualTreeChanged of VisualTreeAttachmentEventArgs // event after which WindowNotificationManager is available
         | ControlNotificationsShow
-        | TimedTick
         | NotificationShowed
         | PositionChanged of SelectionChangedEventArgs
 
-    let timerCmd () =
-        async {
-            do! Async.Sleep 1000
-            return TimedTick
-        }
-
     let notifyOneAsync () =
-        async {
-            do! Async.Sleep 1000
-            return NotifyInfo "async operation completed"
-        }
-        |> Async.executeOnMainThread
+        Cmd.OfAsync.msg(
+            async {
+                do! Async.Sleep 1000
+                return NotifyInfo "async operation completed"
+            }
+        )
 
-    let notifyAsyncStatusUpdates message =
-        async { return NotifyInfo message } |> Async.executeOnMainThread
+    let notifyAsyncStatusUpdates () =
+        Cmd.ofEffect(fun dispatch ->
+            async {
+                dispatch(NotifyInfo "started")
+                do! Async.Sleep(1000)
+                dispatch(NotifyInfo "5")
+                do! Async.Sleep 1000
+                dispatch(NotifyInfo "4")
+                do! Async.Sleep 1000
+                dispatch(NotifyInfo "3")
+                do! Async.Sleep 1000
+                dispatch(NotifyInfo "2")
+                do! Async.Sleep 1000
+                dispatch(NotifyInfo "1")
+                do! Async.Sleep 1000
+                dispatch(NotifyInfo "completed")
+            }
+            |> Async.Start)
 
     let showNotification (notificationManager: INotificationManager) notification =
-        let notificationManager = notificationManager :?> WindowNotificationManager
-        notificationManager.Show(notification)
-        NotificationShowed
+        Cmd.ofEffect(fun dispatch ->
+            Dispatcher.UIThread.Post(fun () ->
+                notificationManager.Show(notification)
+                dispatch(NotificationShowed)))
 
     let controlNotificationsRef = ViewRef<WindowNotificationManager>()
 
@@ -75,61 +89,41 @@ module NotificationsPage =
 
     let update msg model =
         match msg with
-        | TimedTick ->
-            if model.Counter > 0 then
-                { model with
-                    Counter = model.Counter - 1 },
-                Cmd.batch
-                    [ Cmd.OfAsync.msg(timerCmd())
-                      Cmd.OfAsync.msg(notifyAsyncStatusUpdates $"async operation in progress {model.Counter}") ]
-            else
-                model, Cmd.OfAsync.msg(notifyAsyncStatusUpdates "async operation completed")
-
         | ShowManagedNotification ->
-            model,
-            Cmd.ofMsg(
-                showNotification model.NotificationManager (Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information))
-            )
+            model, showNotification model.NotificationManager (Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information))
+
         | ShowCustomManagedNotification ->
             model,
-            Cmd.ofMsg(
-                showNotification
-                    model.NotificationManager
-                    (NotificationViewModel("Hey There!", "Did you know that Avalonia now supports Custom In-Window Notifications?"))
-            )
+            showNotification
+                model.NotificationManager
+                (NotificationViewModel("Hey There!", "Did you know that Avalonia now supports Custom In-Window Notifications?"))
+
         | ShowNativeNotification ->
             model,
-            Cmd.ofMsg(
-                showNotification
-                    model.NotificationManager
-                    (Notification("Error", "Native Notifications are not quite ready. Coming soon.", NotificationType.Error))
-            )
-        | ShowAsyncCompletedNotification -> model, Cmd.OfAsync.msg(notifyOneAsync())
-        | ShowAsyncStatusNotifications -> model, Cmd.OfAsync.msg(timerCmd())
+            showNotification model.NotificationManager (Notification("Error", "Native Notifications are not quite ready. Coming soon.", NotificationType.Error))
 
-        | NotifyInfo message -> model, Cmd.ofMsg(showNotification model.NotificationManager (Notification(message, "", NotificationType.Information)))
+        | ShowAsyncCompletedNotification -> model, notifyOneAsync()
+        | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
+
+        | NotifyInfo message -> model, showNotification model.NotificationManager (Notification(message, "", NotificationType.Information))
         | YesCommand ->
-            model,
-            Cmd.ofMsg(showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today.")))
+            model, showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today."))
 
         | NoCommand ->
-            model,
-            Cmd.ofMsg(showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today.")))
+            model, showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today."))
         (*  WindowNotificationManager can't be used immediately after creating it,
             so we need to wait for it to be attached to the visual tree.
             See https://github.com/AvaloniaUI/Avalonia/issues/5442 *)
         | AttachedToVisualTreeChanged args ->
             { model with
                 NotificationManager = FabApplication.Current.WindowNotificationManager },
-            []
+            Cmd.none
 
         | ControlNotificationsShow ->
-            model,
-            Cmd.ofMsg(
-                showNotification controlNotificationsRef.Value (Notification("Control Notifications", "This notification is shown by the control itself."))
-            )
+            model, showNotification controlNotificationsRef.Value (Notification("Control Notifications", "This notification is shown by the control itself."))
 
-        | NotificationShowed -> model, []
+
+        | NotificationShowed -> model, Cmd.none
 
         | PositionChanged args ->
             let control = args.Source :?> ComboBox
@@ -138,7 +132,7 @@ module NotificationsPage =
 
             { model with
                 NotificationPosition = position },
-            []
+            Cmd.none
 
     let program =
         Program.statefulWithCmd init update

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -57,6 +57,7 @@ module NotificationsPage =
     let notifyAsyncStatusUpdates () =
         Cmd.ofEffect(fun dispatch ->
             async {
+                // This will queue up msgs/notifications that will be dispatched by the Fabulous runner
                 dispatch(NotifyInfo "started")
                 do! Async.Sleep(1000)
                 dispatch(NotifyInfo "5")

--- a/samples/Gallery/Pages/ThemeAwarePage.fs
+++ b/samples/Gallery/Pages/ThemeAwarePage.fs
@@ -57,7 +57,7 @@ module ThemeAwarePage =
 
         | DoNothing -> model, Cmd.none
 
-        | ThemeVariantChanged themeVariant -> { model with ScopeTheme = themeVariant }, []
+        | ThemeVariantChanged themeVariant -> { model with ScopeTheme = themeVariant }, Cmd.none
 
     let program =
         Program.statefulWithCmd init update

--- a/samples/Gallery/Pages/ToggleButtonPage.fs
+++ b/samples/Gallery/Pages/ToggleButtonPage.fs
@@ -44,7 +44,7 @@ module ToggleButtonPage =
                 | true -> "Checked"
                 | false -> "Unchecked"
 
-            { model with Value1 = b; Text1 = text }, []
+            { model with Value1 = b; Text1 = text }, Cmd.none
 
         | CheckedChanged2 b ->
             let text =
@@ -52,7 +52,7 @@ module ToggleButtonPage =
                 | true -> "Checked"
                 | false -> "Unchecked"
 
-            { model with Value2 = b; Text2 = text }, []
+            { model with Value2 = b; Text2 = text }, Cmd.none
 
         | ThreeStateChanged3 b ->
             let text =
@@ -61,7 +61,7 @@ module ToggleButtonPage =
                 | Some false -> "Unchecked"
                 | None -> "Intermediary"
 
-            { model with Value3 = b; Text3 = text }, []
+            { model with Value3 = b; Text3 = text }, Cmd.none
 
         | ThreeStateChanged4 b ->
             let text =
@@ -70,7 +70,7 @@ module ToggleButtonPage =
                 | Some false -> "Unchecked"
                 | None -> "Intermediary"
 
-            { model with Value4 = b; Text4 = text }, []
+            { model with Value4 = b; Text4 = text }, Cmd.none
 
     let program =
         Program.statefulWithCmd init update

--- a/samples/Gallery/Pages/TreeViewPage.fs
+++ b/samples/Gallery/Pages/TreeViewPage.fs
@@ -38,7 +38,7 @@ module TreeViewPage =
 
     let update msg model =
         match msg with
-        | SelectionItemChanged args -> model, []
+        | SelectionItemChanged args -> model, Cmd.none
 
     let program =
         Program.statefulWithCmd init update

--- a/samples/Gallery/Pages/UniformGridPage.fs
+++ b/samples/Gallery/Pages/UniformGridPage.fs
@@ -17,7 +17,7 @@ module UniformGridPage =
 
     let update msg model =
         match msg with
-        | DoNothing -> model, []
+        | DoNothing -> model, Cmd.none
 
     let program =
         Program.statefulWithCmd init update


### PR DESCRIPTION
Fixes #221 

This PR shows a sample of how to dispatch asynchronsly  multiple msgs inside of `Cmd.ofEffect` without having to use `Dispatcher.UIThread.Post` inside of it.

- Init and update should be able to run on any thread
- It is not recommended to access UI-related stuff from either init or update for that exact same reason
- The correct approach is to push back the access to those UI stuff in Cmd, and then make sure those Cmd run on the UI thread if required


This will queue up msgs/notifications that will be dispatched by the Fabulous runner as they are completed
```fsharp
    let notifyAsyncStatusUpdates () =
        Cmd.ofEffect(fun dispatch ->
            async {
                dispatch(NotifyInfo "started")
                do! Async.Sleep(1000)
                dispatch(NotifyInfo "5")
                do! Async.Sleep 1000
                dispatch(NotifyInfo "4")
                do! Async.Sleep 1000
                dispatch(NotifyInfo "3")
                do! Async.Sleep 1000
                dispatch(NotifyInfo "2")
                do! Async.Sleep 1000
                dispatch(NotifyInfo "1")
                do! Async.Sleep 1000
                dispatch(NotifyInfo "completed")
            }
            |> Async.Start)
```

We will delay the access to the UIThread to the actual point were want to show the actual notification `notificationManager.Show(notification)`. So all the rest can executed in any thread.

```fsharp
    let showNotification (notificationManager: INotificationManager) notification =
        Cmd.ofEffect(fun dispatch ->
            Dispatcher.UIThread.Post(fun () ->
                notificationManager.Show(notification)
                dispatch(NotificationShowed)))
```

cc @h0lg 