### PR TITLE
Auto complete fixes

### DIFF
--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -360,11 +360,8 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("MinimumPrefixLength: 1")
 
-                        //TODO the input text is not set to this. Do I misunderstand this parameter?
                         AutoCompleteBox(model.Capitals)
                             .minimumPrefixLength(1)
-                            //TODO this works to preset the text but breaks the dropdown - the menu doesn't open
-                            //.text("ark")
                             .watermark("Select an item")
                             .onTextChanged(model.Text, SearchTextChanged)
                     }
@@ -416,8 +413,6 @@ module AutoCompleteBoxPage =
 
                         AutoCompleteBox(getItemsAsync)
                             .watermark("Select an item")
-                            //TODO this works to preset the text but breaks the dropdown - the menu doesn't open
-                            //.text("prod")
                             .filterMode(AutoCompleteFilterMode.Contains)
                     }
 

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -31,10 +31,6 @@ module AutoCompleteBoxPage =
 
     type Msg =
         | TextChanged of string
-        | SelectionChanged of SelectionChangedEventArgs
-        | OnPopulating of string
-        | OnPopulated of System.Collections.IEnumerable
-        | OnDropDownOpen of bool
         | MultiBindingLoaded of RoutedEventArgs
         | CustomAutoBoxLoaded of RoutedEventArgs
 
@@ -303,10 +299,6 @@ module AutoCompleteBoxPage =
     let update msg model =
         match msg with
         | TextChanged _ -> model, Cmd.none
-        | SelectionChanged _ -> model, Cmd.none
-        | OnPopulating _ -> model, Cmd.none
-        | OnPopulated _ -> model, Cmd.none
-        | OnDropDownOpen isOpen -> { model with IsOpen = isOpen }, Cmd.none
         | MultiBindingLoaded _ ->
             let converter =
                 FuncMultiValueConverter<string, string>(fun parts ->

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -358,7 +358,8 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("MinimumPrefixLength: 1")
 
-                        AutoCompleteBox("", TextChanged, model.Capitals)
+                        //TODO the input text is not set to this. Do I misunderstand this parameter?
+                        AutoCompleteBox("some preset text", TextChanged, model.Capitals)
                             .minimumPrefixLength(1)
                             .watermark("Select an item")
                     }

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -361,6 +361,8 @@ module AutoCompleteBoxPage =
                         //TODO the input text is not set to this. Do I misunderstand this parameter?
                         AutoCompleteBox("some preset text", TextChanged, model.Capitals)
                             .minimumPrefixLength(1)
+                            //TODO this works to preset the text but breaks the dropdown - the menu doesn't open
+                            .text("ark")
                             .watermark("Select an item")
                     }
 
@@ -411,6 +413,8 @@ module AutoCompleteBoxPage =
 
                         AutoCompleteBox("", TextChanged, getItemsAsync)
                             .watermark("Select an item")
+                            //TODO this works to preset the text but breaks the dropdown - the menu doesn't open
+                            .text("prod")
                             .filterMode(AutoCompleteFilterMode.Contains)
                     }
 

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -25,12 +25,13 @@ module AutoCompleteBoxPage =
     type Model =
         { IsOpen: bool
           SelectedItem: string
+          Text: string
           Items: string seq
           Capitals: StateData seq
           Custom: string seq }
 
     type Msg =
-        | TextChanged of string
+        | SearchTextChanged of string
         | MultiBindingLoaded of RoutedEventArgs
         | CustomAutoBoxLoaded of RoutedEventArgs
 
@@ -40,6 +41,7 @@ module AutoCompleteBoxPage =
 
     let init () =
         { IsOpen = false
+          Text = "Arkan"
           SelectedItem = "Item 2"
           Items = [ "Item 1"; "Item 2"; "Item 3"; "Product 1"; "Product 2"; "Product 3" ]
           Capitals =
@@ -298,7 +300,7 @@ module AutoCompleteBoxPage =
 
     let update msg model =
         match msg with
-        | TextChanged _ -> model, Cmd.none
+        | SearchTextChanged args -> { model with Text = args }, Cmd.none
         | MultiBindingLoaded _ ->
             let converter =
                 FuncMultiValueConverter<string, string>(fun parts ->
@@ -359,17 +361,18 @@ module AutoCompleteBoxPage =
                         TextBlock("MinimumPrefixLength: 1")
 
                         //TODO the input text is not set to this. Do I misunderstand this parameter?
-                        AutoCompleteBox("some preset text", TextChanged, model.Capitals)
+                        AutoCompleteBox(model.Capitals)
                             .minimumPrefixLength(1)
                             //TODO this works to preset the text but breaks the dropdown - the menu doesn't open
-                            .text("ark")
+                            //.text("ark")
                             .watermark("Select an item")
+                            .onTextChanged(model.Text, SearchTextChanged)
                     }
 
                     VStack() {
                         TextBlock("MinimumPrefixLength: 3")
 
-                        AutoCompleteBox("", TextChanged, model.Items)
+                        AutoCompleteBox(model.Items)
                             .watermark("Select an item")
                             .minimumPrefixLength(3)
                     }
@@ -377,7 +380,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("MinimumPopulateDelay: 1s")
 
-                        AutoCompleteBox("", TextChanged, model.Items)
+                        AutoCompleteBox(model.Items)
                             .watermark("Select an item")
                             .minimumPopulateDelay(TimeSpan.FromSeconds(1.0))
                     }
@@ -385,7 +388,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("MaxDropDownHeight: 60")
 
-                        AutoCompleteBox("", TextChanged, model.Items)
+                        AutoCompleteBox(model.Items)
                             .maxDropDownHeight(60.0)
                             .watermark("Select an item")
                     }
@@ -393,7 +396,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("Disabled")
 
-                        AutoCompleteBox("", TextChanged, model.Items)
+                        AutoCompleteBox(model.Items)
                             .isEnabled(false)
                             .watermark("Select an item")
                     }
@@ -401,7 +404,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("Multi-Binding")
 
-                        AutoCompleteBox("", TextChanged, model.Capitals)
+                        AutoCompleteBox(model.Capitals)
                             .watermark("Select an item")
                             .reference(multiBindingBoxRef)
                             .filterMode(AutoCompleteFilterMode.Contains)
@@ -411,17 +414,17 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("AsyncBox")
 
-                        AutoCompleteBox("", TextChanged, getItemsAsync)
+                        AutoCompleteBox(getItemsAsync)
                             .watermark("Select an item")
                             //TODO this works to preset the text but breaks the dropdown - the menu doesn't open
-                            .text("prod")
+                            //.text("prod")
                             .filterMode(AutoCompleteFilterMode.Contains)
                     }
 
                     VStack() {
                         TextBlock("Custom AutoComplete")
 
-                        AutoCompleteBox("", TextChanged, model.Custom)
+                        AutoCompleteBox(model.Custom)
                             .watermark("Select an item")
                             .reference(customAutoCompleteBoxRef)
                             .filterMode(AutoCompleteFilterMode.None)
@@ -432,7 +435,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("With Validation Errors")
 
-                        AutoCompleteBox("", TextChanged, model.Items)
+                        AutoCompleteBox(model.Items)
                             .name("ValidationErrors")
                             .filterMode(AutoCompleteFilterMode.None)
                             .dataValidationErrors([ Exception() ])

--- a/samples/Gallery/Pages/DialogsPage.fs
+++ b/samples/Gallery/Pages/DialogsPage.fs
@@ -367,9 +367,10 @@ CanBookmark: {item.Value.CanBookmark}"
                     Button("SaveFilePicker", SaveFilePicker)
                 }
 
-                AutoCompleteBox(model.CurrentFolderBox, CurrentFolderBoxTextChanged, [])
+                AutoCompleteBox([])
                     .watermark("Write full path/uri or well known folder name")
                     .onLoaded(CurrentFolderBoxLoaded)
+                    .onTextChanged(model.CurrentFolderBox, CurrentFolderBoxTextChanged)
 
                 TextBlock("Last picker results:")
                     .isVisible(model.PickerLastResultsVisible)

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -16,9 +16,6 @@ module AutoCompleteBox =
     let Watermark =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.WatermarkProperty
 
-    // let Text =
-    //     Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.TextProperty
-
     let MinimumPrefixLength =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.MinimumPrefixLengthProperty
 

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -16,6 +16,9 @@ module AutoCompleteBox =
     let Watermark =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.WatermarkProperty
 
+    // let Text =
+    //     Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.TextProperty
+
     let MinimumPrefixLength =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.MinimumPrefixLengthProperty
 
@@ -37,9 +40,6 @@ module AutoCompleteBox =
     let TextFilter =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.TextFilterProperty
 
-    let Text =
-        Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.TextProperty
-
     let ItemSelector =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.ItemSelectorProperty
 
@@ -53,7 +53,7 @@ module AutoCompleteBox =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.AsyncPopulatorProperty
 
     let TextChanged =
-        Attributes.defineAvaloniaPropertyWithValueEventData "AutoCompleteBox_TextChanged" AutoCompleteBox.TextProperty id
+        Attributes.defineAvaloniaPropertyWithChangedEvent' "AutoCompleteBox_TextChanged" AutoCompleteBox.TextProperty
 
     let Populating =
         Attributes.defineEvent<PopulatingEventArgs> "AutoCompleteBox_Populating" (fun target -> (target :?> AutoCompleteBox).Populating)
@@ -72,26 +72,14 @@ module AutoCompleteBoxBuilders =
     type Fabulous.Avalonia.View with
 
         /// <summary>Creates a AutoCompleteBox widget.</summary>
-        /// <param name="text">The text to display.</param>
-        /// <param name="fn">Raised when the text changes.</param>
         /// <param name="items">The items to display.</param>
-        static member inline AutoCompleteBox(text: string, fn: string -> 'msg, items: seq<_>) =
-            WidgetBuilder<'msg, IFabAutoCompleteBox>(
-                AutoCompleteBox.WidgetKey,
-                AutoCompleteBox.ItemsSource.WithValue(items),
-                AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn)
-            )
+        static member inline AutoCompleteBox(items: seq<_>) =
+            WidgetBuilder<'msg, IFabAutoCompleteBox>(AutoCompleteBox.WidgetKey, AutoCompleteBox.ItemsSource.WithValue(items))
 
         /// <summary>Creates a AutoCompleteBox widget.</summary>
-        /// <param name="text">The text to display.</param>
-        /// <param name="fn">Raised when the text changes.</param>
         /// <param name="populator">The function to populate the items.</param>
-        static member inline AutoCompleteBox(text: string, fn: string -> 'msg, populator: string -> CancellationToken -> Task<seq<_>>) =
-            WidgetBuilder<'msg, IFabAutoCompleteBox>(
-                AutoCompleteBox.WidgetKey,
-                AutoCompleteBox.AsyncPopulator.WithValue(populator),
-                AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn)
-            )
+        static member inline AutoCompleteBox(populator: string -> CancellationToken -> Task<seq<_>>) =
+            WidgetBuilder<'msg, IFabAutoCompleteBox>(AutoCompleteBox.WidgetKey, AutoCompleteBox.AsyncPopulator.WithValue(populator))
 
 type AutoCompleteBoxModifiers =
     /// <summary>Sets the MinimumPrefixLength property.</summary>
@@ -150,12 +138,9 @@ type AutoCompleteBoxModifiers =
     static member inline textFilter(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string -> string -> bool) =
         this.AddScalar(AutoCompleteBox.TextFilter.WithValue(value))
 
-    /// <summary>Sets the Text property.</summary>
-    /// <param name="this">Current widget.</param>
-    /// <param name="value">The Text value.</param>
     [<Extension>]
-    static member inline text(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string) =
-        this.AddScalar(AutoCompleteBox.Text.WithValue(value))
+    static member inline onTextChanged(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, text: string, fn: string -> 'msg) =
+        this.AddScalar(AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn))
 
     /// <summary>Sets the AutoCompleteBox.ItemSelector property to a custom method that combines the user-entered text
     /// and the selected item to return the new text input value.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -68,7 +68,7 @@ module AutoCompleteBox =
 module AutoCompleteBoxBuilders =
     type Fabulous.Avalonia.View with
 
-        /// <summary>Creates a CalendarDatePicker widget.</summary>
+        /// <summary>Creates a AutoCompleteBox widget.</summary>
         /// <param name="text">The text to display.</param>
         /// <param name="fn">Raised when the text changes.</param>
         /// <param name="items">The items to display.</param>
@@ -79,7 +79,7 @@ module AutoCompleteBoxBuilders =
                 AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn)
             )
 
-        /// <summary>Creates a CalendarDatePicker widget.</summary>
+        /// <summary>Creates a AutoCompleteBox widget.</summary>
         /// <param name="text">The text to display.</param>
         /// <param name="fn">Raised when the text changes.</param>
         /// <param name="populator">The function to populate the items.</param>
@@ -147,16 +147,20 @@ type AutoCompleteBoxModifiers =
     static member inline textFilter(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string -> string -> bool) =
         this.AddScalar(AutoCompleteBox.TextFilter.WithValue(value))
 
-    /// <summary>Sets the ItemSelector property.</summary>
+    /// <summary>Sets the AutoCompleteBox.ItemSelector property to a custom method that combines the user-entered text
+    /// and the selected item to return the new text input value.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="value">The ItemSelector value.</param>
+    /// <param name="value">A custom method receiving the entered text as the first
+    /// and the selected item as the second argument and returns the updated text of the input after selection.</param>
     [<Extension>]
     static member inline itemSelector(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string -> obj -> string) =
         this.AddScalar(AutoCompleteBox.ItemSelector.WithValue(value))
 
-    /// <summary>Sets the TextSelector property.</summary>
+    /// <summary>Sets the AutoCompleteBox.TextSelector property to a custom method that combines the user-entered text
+    /// and the selected item's text to return the new text input value.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="value">The TextSelector value.</param>
+    /// <param name="value">A custom method receiving the entered text as the first
+    /// and the text of the selected item as the second argument and returns the updated text of the input after selection.</param>
     [<Extension>]
     static member inline textSelector(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string -> string -> string) =
         this.AddScalar(AutoCompleteBox.TextSelector.WithValue(value))

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -37,6 +37,9 @@ module AutoCompleteBox =
     let TextFilter =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.TextFilterProperty
 
+    let Text =
+        Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.TextProperty
+
     let ItemSelector =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.ItemSelectorProperty
 
@@ -146,6 +149,13 @@ type AutoCompleteBoxModifiers =
     [<Extension>]
     static member inline textFilter(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string -> string -> bool) =
         this.AddScalar(AutoCompleteBox.TextFilter.WithValue(value))
+
+    /// <summary>Sets the Text property.</summary>
+    /// <param name="this">Current widget.</param>
+    /// <param name="value">The Text value.</param>
+    [<Extension>]
+    static member inline text(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string) =
+        this.AddScalar(AutoCompleteBox.Text.WithValue(value))
 
     /// <summary>Sets the AutoCompleteBox.ItemSelector property to a custom method that combines the user-entered text
     /// and the selected item to return the new text input value.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -68,12 +68,12 @@ module AutoCompleteBox =
 module AutoCompleteBoxBuilders =
     type Fabulous.Avalonia.View with
 
-        /// <summary>Creates a AutoCompleteBox widget.</summary>
+        /// <summary>Creates an AutoCompleteBox widget.</summary>
         /// <param name="items">The items to display.</param>
         static member inline AutoCompleteBox(items: seq<_>) =
             WidgetBuilder<'msg, IFabAutoCompleteBox>(AutoCompleteBox.WidgetKey, AutoCompleteBox.ItemsSource.WithValue(items))
 
-        /// <summary>Creates a AutoCompleteBox widget.</summary>
+        /// <summary>Creates an AutoCompleteBox widget.</summary>
         /// <param name="populator">The function to populate the items.</param>
         static member inline AutoCompleteBox(populator: string -> CancellationToken -> Task<seq<_>>) =
             WidgetBuilder<'msg, IFabAutoCompleteBox>(AutoCompleteBox.WidgetKey, AutoCompleteBox.AsyncPopulator.WithValue(populator))
@@ -135,6 +135,10 @@ type AutoCompleteBoxModifiers =
     static member inline textFilter(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string -> string -> bool) =
         this.AddScalar(AutoCompleteBox.TextFilter.WithValue(value))
 
+    /// <summary>Binds the AutoCompleteBox.TextProperty.</summary>
+    /// <param name="this">Current widget.</param>
+    /// <param name="text">The value to bind.</param>
+    /// <param name="fn">A function mapping the updated text to a 'msg to raise on user change.</param>
     [<Extension>]
     static member inline onTextChanged(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, text: string, fn: string -> 'msg) =
         this.AddScalar(AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn))

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -49,8 +49,7 @@ module AutoCompleteBox =
     let AsyncPopulator =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.AsyncPopulatorProperty
 
-    //TODO rename to just "Text"? This isn't about the event, is it?
-    let TextChanged =
+    let Text =
         Attributes.defineAvaloniaPropertyWithChangedEvent' "AutoCompleteBox_TextChanged" AutoCompleteBox.TextProperty
 
     let Populating =
@@ -138,11 +137,11 @@ type AutoCompleteBoxModifiers =
 
     /// <summary>Binds the AutoCompleteBox.TextProperty.</summary>
     /// <param name="this">Current widget.</param>
-    /// <param name="text">The value to bind.</param>
+    /// <param name="value">The value to bind.</param>
     /// <param name="fn">A function mapping the updated text to a 'msg to raise on user change.</param>
     [<Extension>]
-    static member inline onTextChanged(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, text: string, fn: string -> 'msg) =
-        this.AddScalar(AutoCompleteBox.TextChanged.WithValue(ValueEventData.create text fn))
+    static member inline onTextChanged(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, value: string, fn: string -> 'msg) =
+        this.AddScalar(AutoCompleteBox.Text.WithValue(ValueEventData.create value fn))
 
     /// <summary>Sets the AutoCompleteBox.ItemSelector property to a custom method that combines the user-entered text
     /// and the selected item to return the new text input value.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -49,6 +49,7 @@ module AutoCompleteBox =
     let AsyncPopulator =
         Attributes.defineAvaloniaPropertyWithEquality AutoCompleteBox.AsyncPopulatorProperty
 
+    //TODO rename to just "Text"? This isn't about the event, is it?
     let TextChanged =
         Attributes.defineAvaloniaPropertyWithChangedEvent' "AutoCompleteBox_TextChanged" AutoCompleteBox.TextProperty
 


### PR DESCRIPTION
Includes 
- some documentation fixes and improvements for the `AutoCompleteBox` and
- raises a question concerning the `value` parameter of the Builders not being set on the input on initial render - am I misinterpreting it and have a wrong expectation or is this a bug?