### PR TITLE
Adding a sample for an editable TreeView

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.10" />
     <PackageVersion Include="Fabulous" Version="3.0.0-pre4" />
     <PackageVersion Include="FsCheck.NUnit" Version="2.16.4" />
     <PackageVersion Include="FSharp.Core" Version="8.0.200" />

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -111,6 +111,7 @@
     <Compile Include="Pages\ToolTipPage.fs" />
     <Compile Include="Pages\TreeView\SimpleTreeView.fs" />
     <Compile Include="Pages\TreeView\TreeViewWithNodeInteraction.fs" />
+    <Compile Include="Pages\TreeView\EditableTreeView.fs" />
     <Compile Include="Pages\TreeViewPage.fs" />
     <Compile Include="Pages\TreeDataGrid\CountriesPage.fs" />
     <Compile Include="Pages\TreeDataGrid\FileTreeNodeModel.fs" />

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -3,7 +3,9 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <!-- net8.0-ios is not supported on Linux, so we do not add it there. -->
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <WarningsAsErrors>FS0025</WarningsAsErrors>

--- a/samples/Gallery/Gallery.fsproj
+++ b/samples/Gallery/Gallery.fsproj
@@ -3,9 +3,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
-    <!-- net8.0-ios is not supported on Linux, so we do not add it there. -->
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <WarningsAsErrors>FS0025</WarningsAsErrors>

--- a/samples/Gallery/MainWindow.fs
+++ b/samples/Gallery/MainWindow.fs
@@ -237,14 +237,17 @@ module MainWindow =
             )
 
     let view model =
-        DesktopApplication() {
+        (DesktopApplication() {
             (Window() { hamburgerMenu model })
                 .title("Fabulous Gallery")
                 .menu(createMenu())
                 .width(1024.)
                 .height(800.)
                 .icon("avares://Gallery/Assets/Icons/logo.ico")
-        }
+        })
+#if DEBUG
+            .attachDevTools()
+#endif
         |> _.trayIcon(trayIcon())
 
     let create () =

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -238,31 +238,20 @@ module EditableTreeView =
                         else
                             AddLeaf.appendTo (node.Children |> filter) (Some node)),
                     (fun node ->
-                        HStack(5) {
-                            if AddLeaf.is node then
-                                Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
-                                    .tip(ToolTip("Add a node"))
-                            else
-                                EditableNodeView
-                                    .view(node)
-                                    .horizontalAlignment(HorizontalAlignment.Left)
+TreeViewItem(
+                            HStack(5) {
+                                if AddLeaf.is node then
+                                    Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
+                                        .tip(ToolTip("Add a node"))
+                                else
+                                    EditableNodeView
+                                        .view(node)
+                                        .horizontalAlignment(HorizontalAlignment.Left)
 
-                                Button("x", RemoveNode node).tip(ToolTip("Remove"))
-                        })
-                )
-                    .onSelectionChanged(SelectionItemChanged)
-                    .dock(Dock.Left)
-                    (*  TODO This solution feels awkward because it requires XAML styles,
-                        uses a TwoWay Binding against a mutable node model
-                        and the name of the EditableNode.IsExpanded property is leaking out of this module.
-                        Can either problem be avoided? *)
-                    (*  Include styles binding Avalonia.Controls.TreeViewItem.IsExpanded to EditableNode.IsExpanded
-                        to preserve tree node expansion on re-render, which is triggered by building the TreeView
-                        from a new transient collection returned by the filter method above.
-
-                        See https://github.com/AvaloniaUI/Avalonia/discussions/13903
-                        and https://github.com/AvaloniaUI/Avalonia/discussions/12397 *)
-                    .styles([ "avares://Gallery/Styles/EditableTreeView.xaml" ])
+                                    Button("x", RemoveNode node).tip(ToolTip("Remove"))
+                            }
+                        ).isHitTestVisible(false)
+                         .isExpanded(node.IsExpanded)
 
                 (VStack() {
                     HStack() {

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -234,7 +234,7 @@ module EditableTreeView =
 
                         See https://github.com/AvaloniaUI/Avalonia/discussions/13903
                         and https://github.com/AvaloniaUI/Avalonia/discussions/12397 *)
-                    .styles([ "avares://Gallery/Styles/EditableTreeView.xaml" ])
+                    .styles([ "avares://Playground/Styles/EditableTreeView.xaml" ])
 
                 (VStack() {
                     HStack() {

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -283,24 +283,17 @@ module EditableTreeView =
                         else
                             AddLeaf.appendTo (node.Children |> filter) (Some node)),
                     (fun node ->
-                        (TreeViewItem(
-                            HStack(5) {
-                                if AddLeaf.is node then
-                                    Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
-                                        .tip(ToolTip("Add a node"))
-                                else
-                                    EditableNodeView
-                                        .view(node)
-                                        .horizontalAlignment(HorizontalAlignment.Left)
+                        HStack(5) {
+                            if AddLeaf.is node then
+                                Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
+                                    .tip(ToolTip("Add a node"))
+                            else
+                                EditableNodeView
+                                    .view(node)
+                                    .horizontalAlignment(HorizontalAlignment.Left)
 
-                                    Button("x", RemoveNode node).tip(ToolTip("Remove"))
-                            }
-                        ))
-                            // this prevents buttons from receiving clicks - but without it onSelectionChanged doesn't work
-                            .isHitTestVisible(false)
-                            (*  this doesn't preserve tree node expansion (e.g. on filter)
-                                - and how could it, as there's no setting logic for a two-way binding. Am I missing something? *)
-                            .isExpanded(node.IsExpanded))
+                                Button("x", RemoveNode node).tip(ToolTip("Remove"))
+                        })
                 )
                     .selectionMode(SelectionMode.Multiple)
                     (*  TODO For some reason for nodes on the top level,
@@ -309,6 +302,17 @@ module EditableTreeView =
                     .selectedItems(model.Selected)
                     .onSelectionChanged(SelectionChanged)
                     .dock(Dock.Left)
+                    (*  TODO This solution feels awkward because it requires XAML styles,
+                        uses a TwoWay Binding against a mutable node model
+                        and the name of the EditableNode.IsExpanded property is leaking out of this module.
+                        Can either problem be avoided? *)
+                    (*  Include styles binding Avalonia.Controls.TreeViewItem.IsExpanded to EditableNode.IsExpanded
+                        to preserve tree node expansion on re-render, which is triggered by building the TreeView
+                        from a new transient collection returned by the filter method above.
+
+                        See https://github.com/AvaloniaUI/Avalonia/discussions/13903
+                        and https://github.com/AvaloniaUI/Avalonia/discussions/12397 *)
+                    .styles([ "avares://Gallery/Styles/EditableTreeView.xaml" ])
 
                 (VStack() {
                     HStack() {

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -14,7 +14,6 @@ module FocusAttributes =
     /// Allows setting the Focus on an Avalonia.Input.InputElement
     let Focus =
         Attributes.defineBool "Focus" (fun oldValueOpt newValueOpt node ->
-            Debugger.Break() // TODO never gets hit ?!
             let target = node.Target :?> InputElement
 
             let rec focusAndCleanUp x y =
@@ -69,7 +68,7 @@ module EditableNodeView =
         )
 
     let view node =
-        Component(program, node) { TextBox(node.Name, NameChanged) }
+        Component(program, node) { TextBox(node.Name, NameChanged).focus(node.Name = "") }
 
 module EditableTreeView =
 
@@ -203,13 +202,8 @@ module EditableTreeView =
                                 Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
                                     .tip(ToolTip("Add a node"))
                             else
-                                if node.Name = "" then
-                                    Debugger.Break() // gets hit alright
-
                                 EditableNodeView
                                     .view(node)
-                                    // TODO this doesn't trigger the focus for some reason
-                                    .focus(node.Name = "")
                                     .horizontalAlignment(HorizontalAlignment.Left)
 
                                 Button("x", RemoveNode node).tip(ToolTip("Remove"))

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -238,7 +238,7 @@ module EditableTreeView =
                         else
                             AddLeaf.appendTo (node.Children |> filter) (Some node)),
                     (fun node ->
-TreeViewItem(
+                        (TreeViewItem(
                             HStack(5) {
                                 if AddLeaf.is node then
                                     Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
@@ -250,8 +250,12 @@ TreeViewItem(
 
                                     Button("x", RemoveNode node).tip(ToolTip("Remove"))
                             }
-                        ).isHitTestVisible(false)
-                         .isExpanded(node.IsExpanded)
+                        ))
+                            .isHitTestVisible(false)
+                            .isExpanded(node.IsExpanded))
+                )
+                    .onSelectionChanged(SelectionItemChanged)
+                    .dock(Dock.Left)
 
                 (VStack() {
                     HStack() {

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -1,12 +1,33 @@
 namespace Gallery
 
 open System.Diagnostics
+open System.Runtime.CompilerServices
 open Avalonia.Controls
+open Avalonia.Input
 open Avalonia.Layout
 open Fabulous.Avalonia
 open Fabulous
 
 open type Fabulous.Avalonia.View
+
+module FocusAttributes =
+    /// Allows setting the Focus on an Avalonia.Input.InputElement
+    let Focus =
+        Attributes.defineBool "Focus" (fun oldValueOpt newValueOpt node ->
+            let target = node.Target :?> InputElement
+
+            let rec focusAndCleanUp x y =
+                target.Focus() |> ignore
+                target.AttachedToVisualTree.RemoveHandler(focusAndCleanUp) // to clean up
+
+            if newValueOpt.IsSome && newValueOpt.Value then
+                target.AttachedToVisualTree.AddHandler(focusAndCleanUp))
+
+type FocusModifiers =
+    [<Extension>]
+    /// Sets the Focus on an IFabInputElement if set is true; otherwise does nothing.
+    static member inline focus(this: WidgetBuilder<'msg, #IFabInputElement>, set: bool) =
+        this.AddScalar(FocusAttributes.Focus.WithValue(set))
 
 module EditableNodeView =
     type Node(name, children) =
@@ -183,6 +204,7 @@ module EditableTreeView =
                             else
                                 EditableNodeView
                                     .view(node)
+                                    .focus(node.Name = "")
                                     .horizontalAlignment(HorizontalAlignment.Left)
 
                                 Button("x", RemoveNode node).tip(ToolTip("Remove"))

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -109,9 +109,15 @@ module EditableTreeView =
             updated, Cmd.none
 
         | SelectionItemChanged args ->
-            let node = args.AddedItems[0] :?> EditableNodeView.Node
-            let modelNode = findNodes (fun n -> n = node) model.Nodes |> Seq.tryExactlyOne
-            { model with Selected = modelNode }, Cmd.none
+            let updated =
+                if args.AddedItems.Count > 0 then
+                    let node = args.AddedItems[0] :?> EditableNodeView.Node
+                    let modelNode = findNodes (fun n -> n = node) model.Nodes |> Seq.tryExactlyOne
+                    { model with Selected = modelNode }
+                else
+                    model
+
+            updated, Cmd.none
 
     let program =
         Program.statefulWithCmd init update

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -21,6 +21,10 @@ module FocusAttributes =
                 target.AttachedToVisualTree.RemoveHandler(focusAndCleanUp) // to clean up
 
             if newValueOpt.IsSome && newValueOpt.Value then
+                (* TODO setting the focus on an AutoCompleteBox is broken.
+                    It works for some (probably threading-related) reason if you hit a magic break point here
+                    or in the focusAndCleanUp handler above. *)
+                Debugger.Break()
                 target.AttachedToVisualTree.AddHandler(focusAndCleanUp))
 
 type FocusModifiers =
@@ -72,7 +76,11 @@ module EditableNodeView =
         )
 
     let view node =
-        Component(program, node) { TextBox(node.Name, NameChanged).focus(node.Name = "") }
+        Component(program, node) {
+            AutoCompleteBox([])
+                .onTextChanged(node.Name, NameChanged)
+                .focus(node.Name = "")
+        }
 
 module EditableTreeView =
 

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -14,6 +14,7 @@ module FocusAttributes =
     /// Allows setting the Focus on an Avalonia.Input.InputElement
     let Focus =
         Attributes.defineBool "Focus" (fun oldValueOpt newValueOpt node ->
+            Debugger.Break() // TODO never gets hit ?!
             let target = node.Target :?> InputElement
 
             let rec focusAndCleanUp x y =
@@ -202,8 +203,12 @@ module EditableTreeView =
                                 Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
                                     .tip(ToolTip("Add a node"))
                             else
+                                if node.Name = "" then
+                                    Debugger.Break() // gets hit alright
+
                                 EditableNodeView
                                     .view(node)
+                                    // TODO this doesn't trigger the focus for some reason
                                     .focus(node.Name = "")
                                     .horizontalAlignment(HorizontalAlignment.Left)
 

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -32,6 +32,7 @@ type FocusModifiers =
 type EditableNode(name, children) =
     let mutable _name: string = name
     let mutable _children: EditableNode list = children
+    let mutable _expanded: bool = false
 
     member this.Name
         with get () = _name
@@ -40,6 +41,10 @@ type EditableNode(name, children) =
     member this.Children
         with get () = _children
         and set value = _children <- value
+
+    member this.IsExpanded
+        with get () = _expanded
+        and set value = _expanded <- value
 
 module EditableNodeView =
     type Model = { Node: EditableNode }
@@ -223,6 +228,13 @@ module EditableTreeView =
                 )
                     .onSelectionChanged(SelectionItemChanged)
                     .dock(Dock.Left)
+                    (*  Include styles binding Avalonia.Controls.TreeViewItem.IsExpanded to EditableNode.IsExpanded
+                        to preserve tree node expansion on re-render, which is triggered by building the TreeView
+                        from a new transient collection returned by the filter method above.
+
+                        See https://github.com/AvaloniaUI/Avalonia/discussions/13903
+                        and https://github.com/AvaloniaUI/Avalonia/discussions/12397 *)
+                    .styles([ "avares://Gallery/Styles/EditableTreeView.xaml" ])
 
                 (VStack() {
                     HStack() {

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -12,12 +12,15 @@ module EditableNodeView =
     type Node(name, children) =
 
         let mutable _name: string = name
+        let mutable _children: Node list = children
 
         member this.Name
             with get () = _name
             and set value = _name <- value
 
-        member this.Children = children
+        member this.Children
+            with get () = _children
+            and set value = _children <- value
 
     type Model = { Node: Node }
 
@@ -52,7 +55,9 @@ module EditableTreeView =
         { Nodes: EditableNodeView.Node list
           Selected: EditableNodeView.Node option }
 
-    type Msg = SelectionItemChanged of SelectionChangedEventArgs
+    type Msg =
+        | AddNodeTo of string
+        | SelectionItemChanged of SelectionChangedEventArgs
 
     let branch name (children: EditableNodeView.Node list) = EditableNodeView.Node(name, children)
     let leaf name = branch name []
@@ -78,7 +83,7 @@ module EditableTreeView =
 
         { Nodes = nodes; Selected = None }, []
 
-    let rec findNodes (predicate: EditableNodeView.Node -> bool) (nodes: EditableNodeView.Node list) =
+    let rec findNodes (predicate: EditableNodeView.Node -> bool) (nodes: EditableNodeView.Node seq) =
         let rec matches (node: EditableNodeView.Node) =
             if predicate node then
                 seq { node }
@@ -89,6 +94,20 @@ module EditableTreeView =
 
     let update msg model =
         match msg with
+        | AddNodeTo parentNodeName ->
+            let newNode = leaf ""
+
+            let updated =
+                match findNodes (fun n -> n.Name = parentNodeName) model.Nodes |> Seq.tryExactlyOne with
+                | Some node ->
+                    node.Children <- node.Children @ [ newNode ]
+                    model
+                | None ->
+                    { model with
+                        Nodes = model.Nodes @ [ newNode ] }
+
+            updated, Cmd.none
+
         | SelectionItemChanged args ->
             let node = args.AddedItems[0] :?> EditableNodeView.Node
             let modelNode = findNodes (fun n -> n = node) model.Nodes |> Seq.tryExactlyOne
@@ -106,18 +125,43 @@ module EditableTreeView =
 #endif
         )
 
+    /// Functions for leaf nodes for adding a node to a list.
+    module AddLeaf =
+        let private prefix = "addTo!"
+
+        /// Appends an Add leaf Node (referencing the parentNode or the model if None) to the Node list.
+        let appendTo list (parentNode: EditableNodeView.Node option) =
+            let parentName = parentNode |> Option.map(_.Name) |> Option.defaultValue ""
+            list @ [ leaf(prefix + parentName) ]
+
+        /// Identifies an Add leaf Node.
+        let is (node: EditableNodeView.Node) = node.Name.StartsWith(prefix)
+
+        /// Retrieves the parent Node Name from the Node Name of an Add leaf Node.
+        let getParentNodeName (node: EditableNodeView.Node) = node.Name.Substring(prefix.Length)
+
     let view () =
         Component(program) {
             let! model = Mvu.State
 
             HStack() {
                 TreeView(
-                    model.Nodes,
-                    (_.Children),
+                    AddLeaf.appendTo model.Nodes None,
                     (fun node ->
-                        EditableNodeView
-                            .view(node)
-                            .horizontalAlignment(HorizontalAlignment.Left))
+                        if AddLeaf.is node then
+                            null
+                        else
+                            AddLeaf.appendTo node.Children (Some node)),
+                    (fun node ->
+                        HStack(5) {
+                            if AddLeaf.is node then
+                                Button("+", AddNodeTo(AddLeaf.getParentNodeName node))
+                                    .tip(ToolTip("Add a node"))
+                            else
+                                EditableNodeView
+                                    .view(node)
+                                    .horizontalAlignment(HorizontalAlignment.Left)
+                        })
                 )
                     .onSelectionChanged(SelectionItemChanged)
 

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -38,6 +38,7 @@ type EditableNode(name, children) =
     let mutable _name: string = name
     let mutable _children: EditableNode list = children
     let mutable _expanded: bool = false
+    let mutable _selected: bool = false
 
     //TODO Is a mutable model required or can an updated immutable model be passed to the parent component?
     member this.Name
@@ -51,6 +52,10 @@ type EditableNode(name, children) =
     member this.IsExpanded
         with get () = _expanded
         and set value = _expanded <- value
+
+    member this.IsSelected
+        with get () = _selected
+        and set value = _selected <- value
 
 module EditableNodeView =
     type Model = { Node: EditableNode }

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -1,0 +1,127 @@
+namespace Gallery
+
+open System.Diagnostics
+open Avalonia.Controls
+open Avalonia.Layout
+open Fabulous.Avalonia
+open Fabulous
+
+open type Fabulous.Avalonia.View
+
+module EditableNodeView =
+    type Node(name, children) =
+
+        let mutable _name: string = name
+
+        member this.Name
+            with get () = _name
+            and set value = _name <- value
+
+        member this.Children = children
+
+    type Model = { Node: Node }
+
+    type Msg = NameChanged of string
+
+    let init (node: Node) = { Node = node }
+
+    let update msg (model: Model) =
+        match msg with
+        | NameChanged name ->
+            model.Node.Name <- name
+            model
+
+    let program =
+        Program.stateful init update
+        |> Program.withTrace(fun (format, args) -> Debug.WriteLine(format, box args))
+        |> Program.withExceptionHandler(fun ex ->
+#if DEBUG
+            printfn $"Exception: %s{ex.ToString()}"
+            false // unhandled
+#else
+            true // handled
+#endif
+        )
+
+    let view node =
+        Component(program, node) { TextBox(node.Name, NameChanged) }
+
+module EditableTreeView =
+
+    type Model =
+        { Nodes: EditableNodeView.Node list
+          Selected: EditableNodeView.Node option }
+
+    type Msg = SelectionItemChanged of SelectionChangedEventArgs
+
+    let branch name (children: EditableNodeView.Node list) = EditableNodeView.Node(name, children)
+    let leaf name = branch name []
+
+    let init () =
+        let nodes =
+            [ branch
+                  "Animals"
+                  [ branch "Mammals" [ leaf "Lion"; leaf "Cat"; leaf "Zebra" ]
+                    branch
+                        "Birds"
+                        [ leaf "Eagle"
+                          leaf "Sparrow"
+                          leaf "Dove"
+                          leaf "Owl"
+                          leaf "Parrot"
+                          leaf "Pigeon" ]
+                    leaf "Platypus" ]
+              branch
+                  "Aliens"
+                  [ branch "pyramid-building terrestrial" [ leaf "Alpaca"; leaf "Camel"; leaf "Lama" ]
+                    branch "extra-terrestrial" [ leaf "Alf"; leaf "E.T."; leaf "Klaatu" ] ] ]
+
+        { Nodes = nodes; Selected = None }, []
+
+    let rec findNodes (predicate: EditableNodeView.Node -> bool) (nodes: EditableNodeView.Node list) =
+        let rec matches (node: EditableNodeView.Node) =
+            if predicate node then
+                seq { node }
+            else
+                node.Children |> Seq.collect matches
+
+        nodes |> Seq.collect matches
+
+    let update msg model =
+        match msg with
+        | SelectionItemChanged args ->
+            let node = args.AddedItems[0] :?> EditableNodeView.Node
+            let modelNode = findNodes (fun n -> n = node) model.Nodes |> Seq.tryExactlyOne
+            { model with Selected = modelNode }, Cmd.none
+
+    let program =
+        Program.statefulWithCmd init update
+        |> Program.withTrace(fun (format, args) -> Debug.WriteLine(format, box args))
+        |> Program.withExceptionHandler(fun ex ->
+#if DEBUG
+            printfn $"Exception: %s{ex.ToString()}"
+            false
+#else
+            true
+#endif
+        )
+
+    let view () =
+        Component(program) {
+            let! model = Mvu.State
+
+            HStack() {
+                TreeView(
+                    model.Nodes,
+                    (_.Children),
+                    (fun node ->
+                        EditableNodeView
+                            .view(node)
+                            .horizontalAlignment(HorizontalAlignment.Left))
+                )
+                    .onSelectionChanged(SelectionItemChanged)
+
+                if model.Selected.IsSome then
+                    TextBlock(model.Selected.Value.Name + " selected")
+            }
+        }

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -40,6 +40,18 @@ type EditableNode(name, children) =
     let mutable _expanded: bool = false
     let mutable _selected: bool = false
 
+    // provides info for debugging node expansion and selection
+    let getFlags () =
+        [| let isBranch = _children.IsEmpty |> not
+
+           if isBranch && _expanded then
+               yield 'E'
+
+           if _selected then
+               yield 'S'
+
+           if isBranch then yield 'B' else yield 'L' |]
+
     //TODO Is a mutable model required or can an updated immutable model be passed to the parent component?
     member this.Name
         with get () = _name
@@ -56,6 +68,10 @@ type EditableNode(name, children) =
     member this.IsSelected
         with get () = _selected
         and set value = _selected <- value
+
+    // for debugging
+    override this.ToString() =
+        this.Name + " " + System.String(getFlags())
 
 module EditableNodeView =
     type Model = { Node: EditableNode }

--- a/samples/Gallery/Pages/TreeView/EditableTreeView.fs
+++ b/samples/Gallery/Pages/TreeView/EditableTreeView.fs
@@ -262,7 +262,7 @@ module EditableTreeView =
 
                         See https://github.com/AvaloniaUI/Avalonia/discussions/13903
                         and https://github.com/AvaloniaUI/Avalonia/discussions/12397 *)
-                    .styles([ "avares://Playground/Styles/EditableTreeView.xaml" ])
+                    .styles([ "avares://Gallery/Styles/EditableTreeView.xaml" ])
 
                 (VStack() {
                     HStack() {

--- a/samples/Gallery/Pages/TreeView/TreeViewWithNodeInteraction.fs
+++ b/samples/Gallery/Pages/TreeView/TreeViewWithNodeInteraction.fs
@@ -27,11 +27,13 @@ module NodeView =
         Program.stateful init update
         |> Program.withTrace(fun (format, args) -> Debug.WriteLine(format, box args))
         |> Program.withExceptionHandler(fun ex ->
+            (*  TODO is this exception handling a good practice? What best practices are there in MVU?
+                Is e.g. bubbling exception up to some app-level error log recommended or is it better to log them locally to a facade? *)
 #if DEBUG
             printfn $"Exception: %s{ex.ToString()}"
-            false
+            false // unhandled
 #else
-            true
+            true // handled
 #endif
         )
 

--- a/samples/Gallery/Pages/TreeViewPage.fs
+++ b/samples/Gallery/Pages/TreeViewPage.fs
@@ -10,4 +10,5 @@ module TreeViewPage =
             TabItem("Simple", SimpleTreeView.view())
             TabItem("With TreeViewItem", SimpleTreeView.treeViewItem())
             TabItem("With node interaction", TreeViewWithNodeInteraction.view())
+            TabItem("Editable", EditableTreeView.view())
         }

--- a/samples/Gallery/Styles/EditableTreeView.xaml
+++ b/samples/Gallery/Styles/EditableTreeView.xaml
@@ -10,5 +10,8 @@
           https://github.com/AvaloniaUI/Avalonia/discussions/13903
           https://github.com/AvaloniaUI/Avalonia/discussions/12397  -->
     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+    <!--  Uncomment the following to similarly bind Avalonia.Controls.TreeViewItem.IsSelected to EditableNode.IsSelected
+          This may be useful to preserve tree node selection on re-render. -->
+    <!--<Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />-->
   </Style>
 </Styles>

--- a/samples/Gallery/Styles/EditableTreeView.xaml
+++ b/samples/Gallery/Styles/EditableTreeView.xaml
@@ -1,0 +1,14 @@
+<Styles
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:gallery="clr-namespace:Gallery">
+
+  <!-- strict DataType declaration here is optional and just for reference -->
+  <Style Selector="TreeViewItem" x:DataType="gallery:EditableNode">
+    <!--  Binds Avalonia.Controls.TreeViewItem.IsExpanded to EditableNode.IsExpanded
+          to preserve tree node expansion on re-render, see
+          https://github.com/AvaloniaUI/Avalonia/discussions/13903
+          https://github.com/AvaloniaUI/Avalonia/discussions/12397  -->
+    <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
+  </Style>
+</Styles>

--- a/samples/Playground/App.fs
+++ b/samples/Playground/App.fs
@@ -86,5 +86,9 @@ module App =
         DesktopApplication(Window(content()))
 #endif
 
+#if DEBUG
+            .attachDevTools()
+#endif
+
     let create () =
         FabulousAppBuilder.Configure(FluentTheme, view)

--- a/samples/Playground/App.fs
+++ b/samples/Playground/App.fs
@@ -66,17 +66,7 @@ module App =
 
     let content () =
         Component() {
-            (Dock() {
-                (HStack() { TextBlock("Counter").centerVertical() })
-                    .margin(20.)
-                    .centerHorizontal()
-
-                component1().dock(Dock.Bottom)
-
-                component2().dock(Dock.Bottom)
-
-            })
-                .center()
+            Gallery.EditableTreeView.view()
         }
 
     let view () =

--- a/samples/Playground/App.fs
+++ b/samples/Playground/App.fs
@@ -66,7 +66,17 @@ module App =
 
     let content () =
         Component() {
-            Gallery.EditableTreeView.view()
+            (Dock() {
+                (HStack() { TextBlock("Counter").centerVertical() })
+                    .margin(20.)
+                    .centerHorizontal()
+
+                component1().dock(Dock.Bottom)
+
+                component2().dock(Dock.Bottom)
+
+            })
+                .center()
         }
 
     let view () =

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -3,9 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
-        <!-- net8.0-ios is not supported on Linux, so we do not add it there. -->
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <WarningsAsErrors>FS0025</WarningsAsErrors>

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -22,6 +22,7 @@
         <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
     </PropertyGroup>
     <ItemGroup>
+        <Compile Include="..\Gallery\Pages\TreeView\EditableTreeView.fs" Link="EditableTreeView.fs" />
         <Compile Include="App.fs" />
     </ItemGroup>
     <ItemGroup>

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -3,7 +3,9 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+        <!-- net8.0-ios is not supported on Linux, so we do not add it there. -->
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('linux')) == false">$(TargetFrameworks);net8.0-ios</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <WarningsAsErrors>FS0025</WarningsAsErrors>
@@ -22,8 +24,6 @@
         <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
     </PropertyGroup>
     <ItemGroup>
-        <AvaloniaResource Include="..\Gallery\Styles\EditableTreeView.xaml" Link="Styles\EditableTreeView.xaml" />
-        <Compile Include="..\Gallery\Pages\TreeView\EditableTreeView.fs" Link="EditableTreeView.fs" />
         <Compile Include="App.fs" />
     </ItemGroup>
     <ItemGroup>

--- a/samples/Playground/Playground.fsproj
+++ b/samples/Playground/Playground.fsproj
@@ -22,6 +22,7 @@
         <CodesignKey>Apple Development: Timothé Larivière (X6N2KN9WK3)</CodesignKey>
     </PropertyGroup>
     <ItemGroup>
+        <AvaloniaResource Include="..\Gallery\Styles\EditableTreeView.xaml" Link="Styles\EditableTreeView.xaml" />
         <Compile Include="..\Gallery\Pages\TreeView\EditableTreeView.fs" Link="EditableTreeView.fs" />
         <Compile Include="App.fs" />
     </ItemGroup>

--- a/src/Fabulous.Avalonia/Application.fs
+++ b/src/Fabulous.Avalonia/Application.fs
@@ -167,16 +167,19 @@ module Application =
                     .TopLevel.RendererDiagnostics.DebugOverlays <- value)
 
     let AttachDevTools =
-        Attributes.defineProperty "Application_AttachDevTools" (None, None) (fun target (value: Diagnostics.DevToolsOptions option * Input.KeyGesture option) ->
-            let app = target :?> FabApplication
-            let (options, gesture) = value
+        Attributes.defineProperty
+            "Application_AttachDevTools"
+            (ValueNone, ValueNone)
+            (fun target (value: Diagnostics.DevToolsOptions voption * Input.KeyGesture voption) ->
+                let app = target :?> FabApplication
+                let options, gesture = value
 
-            if options.IsSome then
-                app.MainWindow.AttachDevTools(options.Value)
-            else if gesture.IsSome then
-                app.MainWindow.AttachDevTools(gesture.Value)
-            else
-                app.MainWindow.AttachDevTools())
+                if options.IsSome then
+                    app.MainWindow.AttachDevTools(options.Value)
+                else if gesture.IsSome then
+                    app.MainWindow.AttachDevTools(gesture.Value)
+                else
+                    app.MainWindow.AttachDevTools())
 
     let IsSystemBarVisible =
         Attributes.definePropertyWithGetSet
@@ -265,23 +268,23 @@ type ApplicationModifiers =
     /// <param name="this">The Current widget.</param>
     /// <param name="value">The Developer Tools options.</param>
     [<Extension>]
-    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>, options: Diagnostics.DevToolsOptions) =
-        this.AddScalar(Application.AttachDevTools.WithValue((Some options, None)))
+    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>, value: Diagnostics.DevToolsOptions) =
+        this.AddScalar(Application.AttachDevTools.WithValue((ValueSome value, ValueNone)))
 
     /// <summary>Attaches the Avalonia Developer Tools with the specified gesture.
     /// See https://docs.avaloniaui.net/docs/guides/implementation-guides/developer-tools</summary>
     /// <param name="this">The Current widget.</param>
     /// <param name="value">The key gesture.</param>
     [<Extension>]
-    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>, gesture: Input.KeyGesture) =
-        this.AddScalar(Application.AttachDevTools.WithValue((None, Some gesture)))
+    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>, value: Input.KeyGesture) =
+        this.AddScalar(Application.AttachDevTools.WithValue((ValueNone, ValueSome value)))
 
     /// <summary>Attaches the Avalonia Developer Tools opened using F12.
     /// See https://docs.avaloniaui.net/docs/guides/implementation-guides/developer-tools</summary>
     /// <param name="this">The Current widget.</param>
     [<Extension>]
     static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>) =
-        this.AddScalar(Application.AttachDevTools.WithValue((None, None)))
+        this.AddScalar(Application.AttachDevTools.WithValue((ValueNone, ValueNone)))
 
     /// <summary>Sets the application system bar visibility.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Application.fs
+++ b/src/Fabulous.Avalonia/Application.fs
@@ -166,6 +166,18 @@ module Application =
                 (target :?> FabApplication)
                     .TopLevel.RendererDiagnostics.DebugOverlays <- value)
 
+    let AttachDevTools =
+        Attributes.defineProperty "Application_AttachDevTools" (None, None) (fun target (value: Diagnostics.DevToolsOptions option * Input.KeyGesture option) ->
+            let app = target :?> FabApplication
+            let (options, gesture) = value
+
+            if options.IsSome then
+                app.MainWindow.AttachDevTools(options.Value)
+            else if gesture.IsSome then
+                app.MainWindow.AttachDevTools(gesture.Value)
+            else
+                app.MainWindow.AttachDevTools())
+
     let IsSystemBarVisible =
         Attributes.definePropertyWithGetSet
             "Application_IsSystemBarVisible"
@@ -247,6 +259,29 @@ type ApplicationModifiers =
     [<Extension>]
     static member inline debugOverlays(this: WidgetBuilder<'msg, #IFabApplication>, value: RendererDebugOverlays) =
         this.AddScalar(Application.DebugOverlays.WithValue(value))
+
+    /// <summary>Attaches the Avalonia Developer Tools with the specified options.
+    /// See https://docs.avaloniaui.net/docs/guides/implementation-guides/developer-tools</summary>
+    /// <param name="this">The Current widget.</param>
+    /// <param name="value">The Developer Tools options.</param>
+    [<Extension>]
+    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>, options: Diagnostics.DevToolsOptions) =
+        this.AddScalar(Application.AttachDevTools.WithValue((Some options, None)))
+
+    /// <summary>Attaches the Avalonia Developer Tools with the specified gesture.
+    /// See https://docs.avaloniaui.net/docs/guides/implementation-guides/developer-tools</summary>
+    /// <param name="this">The Current widget.</param>
+    /// <param name="value">The key gesture.</param>
+    [<Extension>]
+    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>, gesture: Input.KeyGesture) =
+        this.AddScalar(Application.AttachDevTools.WithValue((None, Some gesture)))
+
+    /// <summary>Attaches the Avalonia Developer Tools opened using F12.
+    /// See https://docs.avaloniaui.net/docs/guides/implementation-guides/developer-tools</summary>
+    /// <param name="this">The Current widget.</param>
+    [<Extension>]
+    static member inline attachDevTools(this: WidgetBuilder<'msg, #IFabApplication>) =
+        this.AddScalar(Application.AttachDevTools.WithValue((None, None)))
 
     /// <summary>Sets the application system bar visibility.</summary>
     /// <param name="this">Current widget.</param>

--- a/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
+++ b/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
@@ -226,6 +226,7 @@
       FSharp.Core is fixed to a specific version that is not necessarily the latest one.
       This version will be used as the lower bound in the NuGet package
     -->
+    <PackageReference Include="Avalonia.Diagnostics" />
     <PackageReference Condition="'$(UseLocalProjectReference)' != 'true'" Include="Fabulous" VersionOverride="[3.0.0-pre4]" />
     <PackageReference Include="Avalonia" VersionOverride="11.0.10" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />


### PR DESCRIPTION
In this PR I'm trying to raise a few questions and issues I encountered while working with the `TreeView` and `AutoCompleteBox` widgets.

It adds a third tab hosting a sample of an editable `TreeView` to the `Gallery` app's `TreeViewPage` that features **adding, removing, renaming and filtering items while preserving tree node expansion**. While I got that working, the solution involves a XAML style with a Binding that I don't like much.

As a follow-up to https://github.com/fabulous-dev/Fabulous.Avalonia/discussions/231, it includes a working example of **focusing** an added `TextBox` - but trying the same on an `AutoCompleteBox` **doesn't seem to work** unless hitting a magic breakpoint during debugging. See commit [changing input to AutoCompleteBox, breaking focus](https://github.com/fabulous-dev/Fabulous.Avalonia/commit/43f52030e336fa835bb688c82e0f64ca27f4710c).

Note that it includes commits that run the `EditableTreeView` from the `Playground` app built only for dotnet for quicker testing - because building the Gallery takes a while. Those changes are reverted in the last commit.

You should be able to check out different commits to reproduce the different stages of broken and working features as described in the commit messages.

Please find my open questions in the commit [added open questions](https://github.com/fabulous-dev/Fabulous.Avalonia/commit/221063e2a20f30d065d1fa11c782f7627a1442b2).

Thank you for your time and consideration 🙏 