### PR TITLE
Remote-filtered async search

### DIFF
--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -20,6 +20,195 @@ module AutoCompleteBoxPage =
 
         override this.ToString() = this.Name
 
+    let usFederalStates =
+        [ { Name = "Arkansas"
+            Abbreviation = "AR"
+            Capital = "Little Rock" }
+
+          { Name = "California"
+            Abbreviation = "CA"
+            Capital = "Sacramento" }
+
+          { Name = "Colorado"
+            Abbreviation = "CO"
+            Capital = "Denver" }
+
+          { Name = "Connecticut"
+            Abbreviation = "CT"
+            Capital = "Hartford" }
+
+          { Name = "Delaware"
+            Abbreviation = "DE"
+            Capital = "Dover" }
+
+          { Name = "Florida"
+            Abbreviation = "FL"
+            Capital = "Tallahassee" }
+
+          { Name = "Georgia"
+            Abbreviation = "GA"
+            Capital = "Atlanta" }
+
+          { Name = "Hawaii"
+            Abbreviation = "HI"
+            Capital = "Honolulu" }
+
+          { Name = "Idaho"
+            Abbreviation = "ID"
+            Capital = "Boise" }
+
+          { Name = "Illinois"
+            Abbreviation = "IL"
+            Capital = "Springfield" }
+
+          { Name = "Indiana"
+            Abbreviation = "IN"
+            Capital = "Indianapolis" }
+
+          { Name = "Iowa"
+            Abbreviation = "IA"
+            Capital = "Des Moines" }
+
+          { Name = "Kansas"
+            Abbreviation = "KS"
+            Capital = "Topeka" }
+
+          { Name = "Kentucky"
+            Abbreviation = "KY"
+            Capital = "Frankfort" }
+
+          { Name = "Louisiana"
+            Abbreviation = "LA"
+            Capital = "Baton Rouge" }
+
+          { Name = "Maine"
+            Abbreviation = "ME"
+            Capital = "Augusta" }
+
+          { Name = "Maryland"
+            Abbreviation = "MD"
+            Capital = "Annapolis" }
+
+          { Name = "Massachusetts"
+            Abbreviation = "MA"
+            Capital = "Boston" }
+
+          { Name = "Michigan"
+            Abbreviation = "MI"
+            Capital = "Lansing" }
+
+          { Name = "Minnesota"
+            Abbreviation = "MN"
+            Capital = "St. Paul" }
+
+          { Name = "Mississippi"
+            Abbreviation = "MS"
+            Capital = "Jackson" }
+
+          { Name = "Missouri"
+            Abbreviation = "MO"
+            Capital = "Jefferson City" }
+
+          { Name = "Montana"
+            Abbreviation = "MT"
+            Capital = "Helena" }
+
+          { Name = "Nebraska"
+            Abbreviation = "NE"
+            Capital = "Lincoln" }
+
+          { Name = "Nevada"
+            Abbreviation = "NV"
+            Capital = "Carson City" }
+
+          { Name = "New Hampshire"
+            Abbreviation = "NH"
+            Capital = "Concord" }
+
+          { Name = "New Jersey"
+            Abbreviation = "NJ"
+            Capital = "Trenton" }
+
+          { Name = "New Mexico"
+            Abbreviation = "NM"
+            Capital = "Santa Fe" }
+
+          { Name = "New York"
+            Abbreviation = "NY"
+            Capital = "Albany" }
+
+          { Name = "North Carolina"
+            Abbreviation = "NC"
+            Capital = "Raleigh" }
+
+          { Name = "North Dakota"
+            Abbreviation = "ND"
+            Capital = "Bismarck" }
+
+          { Name = "Ohio"
+            Abbreviation = "OH"
+            Capital = "Columbus" }
+
+          { Name = "Oklahoma"
+            Abbreviation = "OK"
+            Capital = "Oklahoma City" }
+
+          { Name = "Oregon"
+            Abbreviation = "OR"
+            Capital = "Salem" }
+
+          { Name = "Pennsylvania"
+            Abbreviation = "PA"
+            Capital = "Harrisburg" }
+
+          { Name = "Rhode Island"
+            Abbreviation = "RI"
+            Capital = "Providence" }
+
+          { Name = "South Carolina"
+            Abbreviation = "SC"
+            Capital = "Columbia" }
+
+          { Name = "South Dakota"
+            Abbreviation = "SD"
+            Capital = "Pierre" }
+
+          { Name = "Tennessee"
+            Abbreviation = "TN"
+            Capital = "Nashville" }
+
+          { Name = "Texas"
+            Abbreviation = "TX"
+            Capital = "Austin" }
+
+          { Name = "Utah"
+            Abbreviation = "UT"
+            Capital = "Salt Lake City" }
+
+          { Name = "Vermont"
+            Abbreviation = "VT"
+            Capital = "Montpelier" }
+
+          { Name = "Virginia"
+            Abbreviation = "VA"
+            Capital = "Richmond" }
+
+          { Name = "Washington"
+            Abbreviation = "WA"
+            Capital = "Olympia" }
+
+          { Name = "West Virginia"
+            Abbreviation = "WV"
+            Capital = "Charleston" }
+
+          { Name = "Wisconsin"
+            Abbreviation = "WI"
+            Capital = "Madison" }
+
+          { Name = "Wyoming"
+            Abbreviation = "WY"
+            Capital = "Cheyenne" } ]
+
     type Model =
         { IsOpen: bool
           SelectedItem: string
@@ -39,197 +228,7 @@ module AutoCompleteBoxPage =
           Text = "Arkan"
           SelectedItem = "Item 2"
           Items = [ "Item 1"; "Item 2"; "Item 3"; "Product 1"; "Product 2"; "Product 3" ]
-          UsFederalStates =
-            [
-
-              { Name = "Arkansas"
-                Abbreviation = "AR"
-                Capital = "Little Rock" }
-
-              { Name = "California"
-                Abbreviation = "CA"
-                Capital = "Sacramento" }
-
-              { Name = "Colorado"
-                Abbreviation = "CO"
-                Capital = "Denver" }
-
-              { Name = "Connecticut"
-                Abbreviation = "CT"
-                Capital = "Hartford" }
-
-              { Name = "Delaware"
-                Abbreviation = "DE"
-                Capital = "Dover" }
-
-              { Name = "Florida"
-                Abbreviation = "FL"
-                Capital = "Tallahassee" }
-
-              { Name = "Georgia"
-                Abbreviation = "GA"
-                Capital = "Atlanta" }
-
-              { Name = "Hawaii"
-                Abbreviation = "HI"
-                Capital = "Honolulu" }
-
-              { Name = "Idaho"
-                Abbreviation = "ID"
-                Capital = "Boise" }
-
-              { Name = "Illinois"
-                Abbreviation = "IL"
-                Capital = "Springfield" }
-
-              { Name = "Indiana"
-                Abbreviation = "IN"
-                Capital = "Indianapolis" }
-
-              { Name = "Iowa"
-                Abbreviation = "IA"
-                Capital = "Des Moines" }
-
-              { Name = "Kansas"
-                Abbreviation = "KS"
-                Capital = "Topeka" }
-
-              { Name = "Kentucky"
-                Abbreviation = "KY"
-                Capital = "Frankfort" }
-
-              { Name = "Louisiana"
-                Abbreviation = "LA"
-                Capital = "Baton Rouge" }
-
-              { Name = "Maine"
-                Abbreviation = "ME"
-                Capital = "Augusta" }
-
-              { Name = "Maryland"
-                Abbreviation = "MD"
-                Capital = "Annapolis" }
-
-              { Name = "Massachusetts"
-                Abbreviation = "MA"
-                Capital = "Boston" }
-
-              { Name = "Michigan"
-                Abbreviation = "MI"
-                Capital = "Lansing" }
-
-              { Name = "Minnesota"
-                Abbreviation = "MN"
-                Capital = "St. Paul" }
-
-              { Name = "Mississippi"
-                Abbreviation = "MS"
-                Capital = "Jackson" }
-
-              { Name = "Missouri"
-                Abbreviation = "MO"
-                Capital = "Jefferson City" }
-
-              { Name = "Montana"
-                Abbreviation = "MT"
-                Capital = "Helena" }
-
-              { Name = "Nebraska"
-                Abbreviation = "NE"
-                Capital = "Lincoln" }
-
-              { Name = "Nevada"
-                Abbreviation = "NV"
-                Capital = "Carson City" }
-
-              { Name = "New Hampshire"
-                Abbreviation = "NH"
-                Capital = "Concord" }
-
-              { Name = "New Jersey"
-                Abbreviation = "NJ"
-                Capital = "Trenton" }
-
-              { Name = "New Mexico"
-                Abbreviation = "NM"
-                Capital = "Santa Fe" }
-
-              { Name = "New York"
-                Abbreviation = "NY"
-                Capital = "Albany" }
-
-              { Name = "North Carolina"
-                Abbreviation = "NC"
-                Capital = "Raleigh" }
-
-              { Name = "North Dakota"
-                Abbreviation = "ND"
-                Capital = "Bismarck" }
-
-              { Name = "Ohio"
-                Abbreviation = "OH"
-                Capital = "Columbus" }
-
-              { Name = "Oklahoma"
-                Abbreviation = "OK"
-                Capital = "Oklahoma City" }
-
-              { Name = "Oregon"
-                Abbreviation = "OR"
-                Capital = "Salem" }
-
-              { Name = "Pennsylvania"
-                Abbreviation = "PA"
-                Capital = "Harrisburg" }
-
-              { Name = "Rhode Island"
-                Abbreviation = "RI"
-                Capital = "Providence" }
-
-              { Name = "South Carolina"
-                Abbreviation = "SC"
-                Capital = "Columbia" }
-
-              { Name = "South Dakota"
-                Abbreviation = "SD"
-                Capital = "Pierre" }
-
-              { Name = "Tennessee"
-                Abbreviation = "TN"
-                Capital = "Nashville" }
-
-              { Name = "Texas"
-                Abbreviation = "TX"
-                Capital = "Austin" }
-
-              { Name = "Utah"
-                Abbreviation = "UT"
-                Capital = "Salt Lake City" }
-
-              { Name = "Vermont"
-                Abbreviation = "VT"
-                Capital = "Montpelier" }
-
-              { Name = "Virginia"
-                Abbreviation = "VA"
-                Capital = "Richmond" }
-
-              { Name = "Washington"
-                Abbreviation = "WA"
-                Capital = "Olympia" }
-
-              { Name = "West Virginia"
-                Abbreviation = "WV"
-                Capital = "Charleston" }
-
-              { Name = "Wisconsin"
-                Abbreviation = "WI"
-                Capital = "Madison" }
-
-              { Name = "Wyoming"
-                Abbreviation = "WY"
-                Capital = "Cheyenne" } ]
-
+          UsFederalStates = usFederalStates
           Custom = [] },
         Cmd.none
 

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -2,14 +2,9 @@ namespace Gallery
 
 open System
 open System.Diagnostics
-open System.Linq.Expressions
-open System.Reflection
-open System.Runtime.CompilerServices
 open System.Threading
 open System.Threading.Tasks
 open Avalonia.Controls
-open Avalonia.Data
-open Avalonia.Data.Converters
 open Avalonia.Interactivity
 open Fabulous
 open Fabulous.Avalonia
@@ -297,24 +292,6 @@ module AutoCompleteBoxPage =
                 String.Join(" ", parts)
         else
             String.Empty
-
-    type Extensions =
-        /// Allows multi-binding a bound property on a control of type T
-        /// to the properties identified by the propertyNames in the specified format.
-        [<Extension>]
-        static member multiBind<'T>(control: obj, boundProperty: Expression<Func<'T, IBinding>>, format: string, [<ParamArray>] propertyNames: string[]) =
-            let binding = MultiBinding()
-            binding.Converter <- FuncMultiValueConverter<obj, string>(fun parts -> String.Format(format, parts |> Seq.toArray))
-
-            for property in propertyNames do
-                binding.Bindings.Add(Binding(property))
-
-            // Get member information from the expression
-            let memberExpression = boundProperty.Body :?> MemberExpression
-            let propertyInfo = memberExpression.Member :?> PropertyInfo
-
-            // Set property value on control
-            propertyInfo.SetValue(control, binding, null)
 
     let update msg model =
         match msg with

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -2,7 +2,6 @@ namespace Gallery
 
 open System
 open System.Diagnostics
-open System.Runtime.CompilerServices
 open System.Threading
 open System.Threading.Tasks
 open Avalonia.Controls
@@ -276,7 +275,6 @@ module AutoCompleteBoxPage =
 
         options |> Array.exists(fun x -> x <> null && x = item)
 
-
     let appendWord (text: string, item: string) =
         if item <> null then
             let parts =
@@ -292,29 +290,6 @@ module AutoCompleteBoxPage =
                 String.Join(" ", parts)
         else
             String.Empty
-
-    module AutoCompleteBoxProperties =
-        /// Allows multi-binding the ValueMemberBinding on an AutoCompleteBox
-        let MultiValueBinding =
-            Attributes.defineSimpleScalar<string * string[]>
-                "AutoCompleteBox_MultiValueBinding"
-                (fun a b -> ScalarAttributeComparers.equalityCompare a b)
-                (fun _ newValueOpt node ->
-                    if newValueOpt.IsSome then
-                        let (format, propertyNames) = newValueOpt.Value
-                        let target = node.Target :?> AutoCompleteBox
-
-                        let rec bindAndCleanUp source args =
-                            target.multiBind<AutoCompleteBox>((fun (box: AutoCompleteBox) -> box.ValueMemberBinding), format, propertyNames)
-                            target.Loaded.RemoveHandler(bindAndCleanUp) // to clean up
-
-                        target.Loaded.AddHandler(bindAndCleanUp))
-
-    type AutoCompleteBoxModifiers =
-        /// Allows multi-binding the ValueMemberBinding on an AutoCompleteBox
-        [<Extension>]
-        static member inline multiBindValue(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, format: string, [<ParamArray>] propertyNames: string[]) =
-            this.AddScalar(AutoCompleteBoxProperties.MultiValueBinding.WithValue((format, propertyNames)))
 
     let update msg model =
         match msg with

--- a/samples/Gallery/Pages/AutoCompleteBoxPage.fs
+++ b/samples/Gallery/Pages/AutoCompleteBoxPage.fs
@@ -25,7 +25,7 @@ module AutoCompleteBoxPage =
           SelectedItem: string
           Text: string
           Items: string seq
-          Capitals: StateData seq
+          UsFederalStates: StateData seq
           Custom: string seq }
 
     type Msg =
@@ -39,7 +39,7 @@ module AutoCompleteBoxPage =
           Text = "Arkan"
           SelectedItem = "Item 2"
           Items = [ "Item 1"; "Item 2"; "Item 3"; "Product 1"; "Product 2"; "Product 3" ]
-          Capitals =
+          UsFederalStates =
             [
 
               { Name = "Arkansas"
@@ -339,7 +339,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("MinimumPrefixLength: 1")
 
-                        AutoCompleteBox(model.Capitals)
+                        AutoCompleteBox(model.UsFederalStates)
                             .minimumPrefixLength(1)
                             .watermark("Select an item")
                             .onTextChanged(model.Text, SearchTextChanged)
@@ -380,7 +380,7 @@ module AutoCompleteBoxPage =
                     VStack() {
                         TextBlock("Multi-Binding")
 
-                        AutoCompleteBox(model.Capitals)
+                        AutoCompleteBox(model.UsFederalStates)
                             .watermark("Select an item")
                             .filterMode(AutoCompleteFilterMode.Contains)
                             .multiBindValue("{0} ({1})", nameof stateData.Name, nameof stateData.Abbreviation)

--- a/src/Fabulous.Avalonia/BindingExtensions.fs
+++ b/src/Fabulous.Avalonia/BindingExtensions.fs
@@ -9,10 +9,13 @@ open Avalonia.Data.Converters
 
 type BindingExtensions =
 
-    /// Allows multi-binding a bound property on a control of type T
-    /// to the properties identified by the propertyNames in the specified format.
+    /// <summary>Allows multi-binding a bound property on a control of type T to the properties identified by the propertyNames in the specified format.</summary>
+    /// <param name="control">The control to bind the property to.</param>
+    /// <param name="property">The bound property to bind to.</param>
+    /// <param name="format">The format string to use when binding the properties.</param>
+    /// <param name="propertyNames">The property names to bind to the bound property.</param>
     [<Extension>]
-    static member multiBind<'T>(control: obj, boundProperty: Expression<Func<'T, IBinding>>, format: string, [<ParamArray>] propertyNames: string[]) =
+    static member multiBind<'T>(control: obj, property: Expression<Func<'T, IBinding>>, format: string, [<ParamArray>] propertyNames: string array) =
         let binding = MultiBinding()
         binding.Converter <- FuncMultiValueConverter<obj, string>(fun parts -> String.Format(format, parts |> Seq.toArray))
 
@@ -20,7 +23,7 @@ type BindingExtensions =
             binding.Bindings.Add(Binding(property))
 
         // Get member information from the expression
-        let memberExpression = boundProperty.Body :?> MemberExpression
+        let memberExpression = property.Body :?> MemberExpression
         let propertyInfo = memberExpression.Member :?> PropertyInfo
 
         // Set property value on control

--- a/src/Fabulous.Avalonia/BindingExtensions.fs
+++ b/src/Fabulous.Avalonia/BindingExtensions.fs
@@ -1,0 +1,27 @@
+namespace Fabulous.Avalonia
+
+open System
+open System.Linq.Expressions
+open System.Reflection
+open System.Runtime.CompilerServices
+open Avalonia.Data
+open Avalonia.Data.Converters
+
+type BindingExtensions =
+
+    /// Allows multi-binding a bound property on a control of type T
+    /// to the properties identified by the propertyNames in the specified format.
+    [<Extension>]
+    static member multiBind<'T>(control: obj, boundProperty: Expression<Func<'T, IBinding>>, format: string, [<ParamArray>] propertyNames: string[]) =
+        let binding = MultiBinding()
+        binding.Converter <- FuncMultiValueConverter<obj, string>(fun parts -> String.Format(format, parts |> Seq.toArray))
+
+        for property in propertyNames do
+            binding.Bindings.Add(Binding(property))
+
+        // Get member information from the expression
+        let memberExpression = boundProperty.Body :?> MemberExpression
+        let propertyInfo = memberExpression.Member :?> PropertyInfo
+
+        // Set property value on control
+        propertyInfo.SetValue(control, binding, null)

--- a/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
+++ b/src/Fabulous.Avalonia/Fabulous.Avalonia.fsproj
@@ -31,6 +31,7 @@
     <None Include="..\Fabulous.Avalonia.props" PackagePath="build/Fabulous.Avalonia.props" Pack="true" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BindingExtensions.fs" />
     <Compile Include="ViewNode.fs" />
     <Compile Include="_ImageSource.fs" />
     <Compile Include="Attributes.fs" />

--- a/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/AutoCompleteBox.fs
@@ -66,15 +66,15 @@ module AutoCompleteBox =
 
     /// Allows multi-binding the ValueMemberBinding on an AutoCompleteBox
     let MultiValueBinding =
-        Attributes.defineSimpleScalar<string * string[]>
+        Attributes.defineSimpleScalar<string * string array>
             "AutoCompleteBox_MultiValueBinding"
-            (fun a b -> ScalarAttributeComparers.equalityCompare a b)
+            ScalarAttributeComparers.equalityCompare
             (fun _ newValueOpt node ->
                 if newValueOpt.IsSome then
-                    let (format, propertyNames) = newValueOpt.Value
+                    let format, propertyNames = newValueOpt.Value
                     let target = node.Target :?> AutoCompleteBox
 
-                    let rec bindAndCleanUp source args =
+                    let rec bindAndCleanUp _ _ =
                         target.multiBind<AutoCompleteBox>((fun (box: AutoCompleteBox) -> box.ValueMemberBinding), format, propertyNames)
                         target.Loaded.RemoveHandler(bindAndCleanUp) // to clean up
 
@@ -210,7 +210,10 @@ type AutoCompleteBoxModifiers =
     static member inline reference(this: WidgetBuilder<'msg, IFabAutoCompleteBox>, value: ViewRef<AutoCompleteBox>) =
         this.AddScalar(ViewRefAttributes.ViewRef.WithValue(value.Unbox))
 
-    /// Allows multi-binding the ValueMemberBinding on an AutoCompleteBox
+    /// <Summary>Allows multi-binding the ValueMemberBinding on an AutoCompleteBox.</Summary>
+    /// <param name="this">Current widget.</param>
+    /// <param name="format">The format string to use.</param>
+    /// <param name="propertyNames">The property names to bind.</param>
     [<Extension>]
-    static member inline multiBindValue(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, format: string, [<ParamArray>] propertyNames: string[]) =
+    static member inline multiBindValue(this: WidgetBuilder<'msg, #IFabAutoCompleteBox>, format: string, [<ParamArray>] propertyNames: string array) =
         this.AddScalar(AutoCompleteBox.MultiValueBinding.WithValue((format, propertyNames)))


### PR DESCRIPTION
Hey Fabulous Avalonia team,

in this PR I've **refactored multi-binding** a property into a generic and that of the `AutoCompleteBox.ValueMemberBinding` into a specific extension allowing to set the format and property names used in the `MultiBinding` and its `Converter` easily.

I also added an **example of a remote-filtered async search** to raise an issue about some erratic behaviour I noticed:
_**If you try completely new search terms in quick succession, you'll notice that the dropdown sometimes gets populated with results for your previous searches.**_ You'll find some debugging in place that hopefully helps demonstrate what happens.

Thank you for your consideration!