### PR TITLE
Custom notification content

### DIFF
--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -101,11 +101,9 @@ module NotificationsPage =
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
 
         | NotifyInfo message -> model, showNotification model.NotificationManager (Notification(message, "", NotificationType.Information))
-        | YesCommand ->
-            model, showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today."))
+        | YesCommand -> model, showNotification model.NotificationManager (Notification("Wise choice.", "You better!"))
+        | NoCommand -> model, showNotification model.NotificationManager (Notification("What?", "Why wouldn't you?"))
 
-        | NoCommand ->
-            model, showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today."))
         (*  WindowNotificationManager can't be used immediately after creating it,
             so we need to wait for it to be attached to the visual tree.
             See https://github.com/AvaloniaUI/Avalonia/issues/5442 *)
@@ -188,7 +186,7 @@ module NotificationsPage =
                     })
                         .dock(Dock.Top)
 
-                    CustomNotification("Avalonia Notifications", "Start adding notifications to your app today.", YesCommand, NoCommand)
+                    InlinedYesNoQuestion("Can you believe it?", "You can also roll your own inlined dialogs using standard widgets.", YesCommand, NoCommand)
                         .dock(Dock.Top)
 
                     NotificationCard(false, "This is a notification card.")

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -21,8 +21,8 @@ module NotificationsPage =
           ShowInlined: bool }
 
     type Msg =
-        | ShowManagedNotification
-        | ShowCustomManagedNotification
+        | ShowPlainNotification
+        | ShowCustomPlainNotification
         | ShowNativeNotification
         | ShowAsyncCompletedNotification
         | ShowAsyncStatusNotifications
@@ -89,10 +89,10 @@ module NotificationsPage =
 
     let update msg model =
         match msg with
-        | ShowManagedNotification ->
+        | ShowPlainNotification ->
             model, showNotification model.NotificationManager (Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information))
 
-        | ShowCustomManagedNotification ->
+        | ShowCustomPlainNotification ->
             model,
             showNotification model.NotificationManager (notification "Hey There!" "Did you know that Avalonia now supports Custom In-Window Notifications?")
 
@@ -155,10 +155,10 @@ module NotificationsPage =
                         .classes([ "h2" ])
                         .textWrapping(TextWrapping.Wrap)
 
-                    Button("Show Standard Managed Notification", ShowManagedNotification)
+                    Button("A plain Notification", ShowPlainNotification)
                         .dock(Dock.Top)
 
-                    Button("Show Custom Managed Notification", ShowCustomManagedNotification)
+                    Button("A custom plain Notification", ShowCustomPlainNotification)
                         .dock(Dock.Top)
 
                     Button("Notify async operation completed", ShowAsyncCompletedNotification)

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -17,7 +17,8 @@ open type Fabulous.Avalonia.View
 module NotificationsPage =
     type Model =
         { NotificationManager: INotificationManager
-          NotificationPosition: NotificationPosition }
+          NotificationPosition: NotificationPosition
+          ShowInlined: bool }
 
     type Msg =
         | ShowManagedNotification
@@ -25,6 +26,7 @@ module NotificationsPage =
         | ShowNativeNotification
         | ShowAsyncCompletedNotification
         | ShowAsyncStatusNotifications
+        | ToggleInlinedNotification
         | NotifyInfo of string
         | YesCommand
         | NoCommand
@@ -81,7 +83,8 @@ module NotificationsPage =
 
     let init () =
         { NotificationManager = null
-          NotificationPosition = NotificationPosition.TopRight },
+          NotificationPosition = NotificationPosition.TopRight
+          ShowInlined = false },
         []
 
     let update msg model =
@@ -99,6 +102,7 @@ module NotificationsPage =
 
         | ShowAsyncCompletedNotification -> model, notifyOneAsync()
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
+        | ToggleInlinedNotification -> {model with ShowInlined = not model.ShowInlined}, Cmd.none
 
         | NotifyInfo message -> model, showNotification model.NotificationManager (Notification(message, "", NotificationType.Information))
         | YesCommand -> model, showNotification model.NotificationManager (Notification("Wise choice.", "You better!"))
@@ -163,6 +167,9 @@ module NotificationsPage =
                     Button("Notify status updates from async operation", ShowAsyncStatusNotifications)
                         .dock(Dock.Top)
 
+                    Button("Toggle inlined notifications", ToggleInlinedNotification)
+                        .dock(Dock.Top)
+
                     TextBlock("Widget-only notification manager.")
                         .dock(Dock.Top)
                         .margin(2.)
@@ -187,10 +194,12 @@ module NotificationsPage =
                         .dock(Dock.Top)
 
                     InlinedYesNoQuestion("Can you believe it?", "You can also roll your own inlined dialogs using standard widgets.", YesCommand, NoCommand)
+                        .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 
-                    NotificationCard(false, "This is a notification card.")
-                        .size(200., 100.)
+                    NotificationCard(not model.ShowInlined, "I was here all along, just hidden!")
+                        .isVisible(model.ShowInlined)
+                        .size(300., 70.)
                         .dock(Dock.Top)
                         .padding(10)
                         .borderBrush(SolidColorBrush(Colors.Blue))

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -76,6 +76,7 @@ module NotificationsPage =
                 let widget = content.Compile()
                 let widgetDef = WidgetDefinitionStore.get widget.Key
 
+                // TODO how to attach or create the view? how to get TreeContext and EnvironmentContext?
                 (*let struct (_node, view) =
                     widgetDef.CreateView(widget, ...?, ...?, ValueNone)
 
@@ -219,6 +220,7 @@ module NotificationsPage =
                         .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 
+                    //TODO toggling the isClosed flag seems to do nothing. Why include it in the builders at all?
                     NotificationCard(not model.ShowInlined, "I was here all along, just hidden!")
                         .isVisible(model.ShowInlined)
                         .size(300., 70.)

--- a/samples/Gallery/Widgets.fs
+++ b/samples/Gallery/Widgets.fs
@@ -69,7 +69,7 @@ open type Fabulous.Avalonia.View
 module CustomNotificationBuilders =
     type Fabulous.Avalonia.View with
 
-        static member CustomNotification(title: string, message: string, yesCommand: 'msg, noCommand: 'msg) =
+        static member InlinedYesNoQuestion(title: string, message: string, yesCommand: 'msg, noCommand: 'msg) =
             Border(
                 Grid(coldefs = [ Auto; Star ], rowdefs = [ Auto ]) {
                     (Panel() {

--- a/samples/Gallery/Widgets.fs
+++ b/samples/Gallery/Widgets.fs
@@ -1,4 +1,4 @@
-namespace Gallery
+﻿namespace Gallery
 
 open System.Runtime.CompilerServices
 open Avalonia.Media
@@ -73,7 +73,7 @@ module CustomNotificationBuilders =
             Border(
                 Grid(coldefs = [ Auto; Star ], rowdefs = [ Auto ]) {
                     (Panel() {
-                        TextBlock("&#xE115;")
+                        TextBlock("❔")
                             .foreground(SolidColorBrush(Colors.White))
                             .fontWeight(FontWeight.Bold)
                             .fontSize(20.)


### PR DESCRIPTION
Dear Fabulous team,

I was exploring the Avalonia `WindowNotificationManager` to see whether it supports rendering notifications with custom content and found the following alternative `Show` methods accepting an `object content` argument that looks like it could be what I'm looking for:
https://github.com/AvaloniaUI/Avalonia/blob/88bfecbee03f1bddbcc193b1890c9ac0665b6b2f/src/Avalonia.Controls/Notifications/WindowNotificationManager.cs#L96-L177

Can they be used to render content from a `WidgetBuilder`? In this PR I try to add a working example for that - including buttons that interop with the MVU program. But I get stuck at creating the view. I don't understand Fabulous enough to know how to get hold of the `EnvironmentContext` and `ViewTreeContext` I need (or an `IViewNode` to borrow them from).

Please have a look at my attempt. Do you have an idea how this can be achieved?

Also included: Toggling the in-lined notification examples on the page to make for a more realistic use case. 