### PR TITLE
Custom notification content 2

### DIFF
--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -33,29 +33,6 @@ module NotificationsPage =
         | NotificationShown
         | PositionChanged of SelectionChangedEventArgs
 
-    type WindowNotificationManager with
-        member this.Show(content: WidgetBuilder<'msg, 'marker>) =
-            let widget = content.Compile()
-            let widgetDef = WidgetDefinitionStore.get widget.Key
-            let logger = ProgramDefaults.defaultLogger()
-            let syncAction = ViewHelpers.defaultSyncAction
-
-            let treeContext: ViewTreeContext =
-                { CanReuseView = ViewHelpers.canReuseView
-                  GetViewNode = ViewNode.get
-                  GetComponent = Component.get
-                  SetComponent = Component.set
-                  SyncAction = syncAction
-                  Logger = logger
-                  Dispatch = ignore }
-
-            let envContext = new EnvironmentContext(logger)
-
-            let struct (_node, view) =
-                widgetDef.CreateView(widget, envContext, treeContext, ValueNone)
-
-            this.Show(view)
-
     let notifyOneAsync () =
         Cmd.OfAsync.msg(
             async {

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -101,11 +101,9 @@ module NotificationsPage =
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
 
         | NotifyInfo message -> model, showNotification model.NotificationManager (Notification(message, "", NotificationType.Information))
-        | YesCommand ->
-            model, showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today."))
+        | YesCommand -> model, showNotification model.NotificationManager (Notification("Wise choice.", "You better!"))
+        | NoCommand -> model, showNotification model.NotificationManager (Notification("What?", "Why wouldn't you?"))
 
-        | NoCommand ->
-            model, showNotification model.NotificationManager (Notification("Avalonia Notifications", "Start adding notifications to your app today."))
         (*  WindowNotificationManager can't be used immediately after creating it,
             so we need to wait for it to be attached to the visual tree.
             See https://github.com/AvaloniaUI/Avalonia/issues/5442 *)
@@ -188,7 +186,7 @@ module NotificationsPage =
                     })
                         .dock(Dock.Top)
 
-                    CustomNotification("Avalonia Notifications", "Start adding notifications to your app today.", YesCommand, NoCommand)
+                    InlinedYesNoQuestion("Can you believe it?", "You can also roll your own inlined dialogs using standard widgets.", YesCommand, NoCommand)
                         .dock(Dock.Top)
 
                     NotificationCard(false, "This is a notification card.")

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -21,8 +21,8 @@ module NotificationsPage =
           ShowInlined: bool }
 
     type Msg =
-        | ShowManagedNotification
-        | ShowCustomManagedNotification
+        | ShowPlainNotification
+        | ShowCustomPlainNotification
         | ShowNativeNotification
         | ShowAsyncCompletedNotification
         | ShowAsyncStatusNotifications
@@ -89,10 +89,10 @@ module NotificationsPage =
 
     let update msg model =
         match msg with
-        | ShowManagedNotification ->
+        | ShowPlainNotification ->
             model, showNotification model.NotificationManager (Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information))
 
-        | ShowCustomManagedNotification ->
+        | ShowCustomPlainNotification ->
             model,
             showNotification model.NotificationManager (notification "Hey There!" "Did you know that Avalonia now supports Custom In-Window Notifications?")
 
@@ -155,10 +155,10 @@ module NotificationsPage =
                         .classes([ "h2" ])
                         .textWrapping(TextWrapping.Wrap)
 
-                    Button("Show Standard Managed Notification", ShowManagedNotification)
+                    Button("A plain Notification", ShowPlainNotification)
                         .dock(Dock.Top)
 
-                    Button("Show Custom Managed Notification", ShowCustomManagedNotification)
+                    Button("A custom plain Notification", ShowCustomPlainNotification)
                         .dock(Dock.Top)
 
                     Button("Notify async operation completed", ShowAsyncCompletedNotification)

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -17,7 +17,8 @@ open type Fabulous.Avalonia.View
 module NotificationsPage =
     type Model =
         { NotificationManager: INotificationManager
-          NotificationPosition: NotificationPosition }
+          NotificationPosition: NotificationPosition
+          ShowInlined: bool }
 
     type Msg =
         | ShowManagedNotification
@@ -25,6 +26,7 @@ module NotificationsPage =
         | ShowNativeNotification
         | ShowAsyncCompletedNotification
         | ShowAsyncStatusNotifications
+        | ToggleInlinedNotification
         | NotifyInfo of string
         | YesCommand
         | NoCommand
@@ -81,7 +83,8 @@ module NotificationsPage =
 
     let init () =
         { NotificationManager = null
-          NotificationPosition = NotificationPosition.TopRight },
+          NotificationPosition = NotificationPosition.TopRight
+          ShowInlined = false },
         []
 
     let update msg model =
@@ -99,6 +102,7 @@ module NotificationsPage =
 
         | ShowAsyncCompletedNotification -> model, notifyOneAsync()
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
+        | ToggleInlinedNotification -> {model with ShowInlined = not model.ShowInlined}, Cmd.none
 
         | NotifyInfo message -> model, showNotification model.NotificationManager (Notification(message, "", NotificationType.Information))
         | YesCommand -> model, showNotification model.NotificationManager (Notification("Wise choice.", "You better!"))
@@ -163,6 +167,9 @@ module NotificationsPage =
                     Button("Notify status updates from async operation", ShowAsyncStatusNotifications)
                         .dock(Dock.Top)
 
+                    Button("Toggle inlined notifications", ToggleInlinedNotification)
+                        .dock(Dock.Top)
+
                     TextBlock("Widget-only notification manager.")
                         .dock(Dock.Top)
                         .margin(2.)
@@ -187,10 +194,12 @@ module NotificationsPage =
                         .dock(Dock.Top)
 
                     InlinedYesNoQuestion("Can you believe it?", "You can also roll your own inlined dialogs using standard widgets.", YesCommand, NoCommand)
+                        .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 
-                    NotificationCard(false, "This is a notification card.")
-                        .size(200., 100.)
+                    NotificationCard(not model.ShowInlined, "I was here all along, just hidden!")
+                        .isVisible(model.ShowInlined)
+                        .size(300., 70.)
                         .dock(Dock.Top)
                         .padding(10)
                         .borderBrush(SolidColorBrush(Colors.Blue))

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -116,7 +116,7 @@ module NotificationsPage =
                 let struct (_node, view) =
                     widgetDef.CreateView(widget, envContext, treeContext, ValueNone)
 
-                notificationManager.Show(view)))
+                notificationManager.Show(view, NotificationType.Warning, TimeSpan.Zero)))
 
     let controlNotificationsRef = ViewRef<WindowNotificationManager>()
 

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -162,27 +162,37 @@ module NotificationsPage =
     let update msg model =
         match msg with
         | ShowPlainNotification ->
-            model, showNotification model.NotificationManager (Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information))
+            model,
+            Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information)
+            |> showNotification model.NotificationManager
 
         | ShowCustomPlainNotification ->
             model,
-            showNotification model.NotificationManager (notification "Hey There!" "Did you know that Avalonia now supports Custom In-Window Notifications?")
+            notification "Hey There!" "Did you know that Avalonia now supports Custom In-Window Notifications?"
+            |> showNotification model.NotificationManager
 
         | ShowCustomManagedNotification ->
-            model, showNotificationContent model.NotificationManager (questionContent "Can you dig it?" "You can use standard widgets in notifications!")
+            model,
+            questionContent "Can you dig it?" "You can use standard widgets in notifications!"
+            |> showNotificationContent model.NotificationManager
 
         | ShowNativeNotification ->
             model,
-            showNotification model.NotificationManager (Notification("Error", "Native Notifications are not quite ready. Coming soon.", NotificationType.Error))
+            Notification("Error", "Native Notifications are not quite ready. Coming soon.", NotificationType.Error)
+            |> showNotification model.NotificationManager
 
         | ShowAsyncCompletedNotification -> model, notifyOneAsync()
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
+
         | ToggleInlinedNotification ->
             { model with
                 ShowInlined = not model.ShowInlined },
             Cmd.none
 
-        | NotifyInfo message -> model, showNotification model.NotificationManager (Notification(message, "", NotificationType.Information))
+        | NotifyInfo message ->
+            model,
+            Notification(message, "", NotificationType.Information)
+            |> showNotification model.NotificationManager
 
         (*  WindowNotificationManager can't be used immediately after creating it,
             so we need to wait for it to be attached to the visual tree.
@@ -194,7 +204,6 @@ module NotificationsPage =
 
         | ControlNotificationsShow ->
             model, showNotification controlNotificationsRef.Value (Notification("Control Notifications", "This notification is shown by the control itself."))
-
 
         | NotificationShown -> model, Cmd.none
 

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -240,8 +240,10 @@ module NotificationsPage =
                         .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 
+                    //TODO this is always shown - indepedendent of model.ShowInlined. I.e, NotificationCard isClosed flag is not working!
                     // Demonstrate NotificationCard controlled solely via its IsClosed flag. Avoid .isVisible, which masks the effect.
                     NotificationCard(not model.ShowInlined, "I was here all along, just hidden!")
+                        //.isVisible(model.ShowInlined) // but if you uncomment this, toggling works!
                         .size(300., 70.)
                         .dock(Dock.Top)
                         .padding(10)

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -76,6 +76,7 @@ module NotificationsPage =
                 let widget = content.Compile()
                 let widgetDef = WidgetDefinitionStore.get widget.Key
 
+                // TODO how to attach or create the view? how to get TreeContext and EnvironmentContext?
                 (*let struct (_node, view) =
                     widgetDef.CreateView(widget, ...?, ...?, ValueNone)
 
@@ -219,6 +220,7 @@ module NotificationsPage =
                         .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 
+                    //TODO toggling the isClosed flag seems to do nothing. Why include it in the builders at all?
                     NotificationCard(not model.ShowInlined, "I was here all along, just hidden!")
                         .isVisible(model.ShowInlined)
                         .size(300., 70.)

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -121,16 +121,6 @@ module NotificationsPage =
 
     let controlNotificationsRef = ViewRef<WindowNotificationManager>()
 
-    let notification title message =
-        { new INotification with
-            member this.Title = title
-            member this.Message = message
-            member this.Expiration = TimeSpan.FromSeconds(5.)
-            member this.OnClick = Action(fun _ -> Console.WriteLine("Clicked"))
-            member this.OnClose = Action(fun _ -> Console.WriteLine("Closed"))
-            member this.Type = NotificationType.Error }
-
-
     let init () =
         { NotificationManager = null
           NotificationPosition = NotificationPosition.TopRight
@@ -168,7 +158,13 @@ module NotificationsPage =
 
         | ShowCustomPlainNotification ->
             model,
-            notification "Hey There!" "Did you know that Avalonia now supports Custom In-Window Notifications?"
+            { new INotification with
+                member this.Title = "You can implement custom Notifications"
+                member this.Message = "via the INotification interface."
+                member this.Expiration = TimeSpan.FromSeconds(5.)
+                member this.OnClick = Action(fun _ -> Console.WriteLine("Clicked"))
+                member this.OnClose = Action(fun _ -> Console.WriteLine("Closed"))
+                member this.Type = NotificationType.Error }
             |> showNotification model.NotificationManager
 
         | ShowCustomManagedNotification ->

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -104,9 +104,7 @@ module NotificationsPage =
         []
 
     let private createYesNoQuestion title question =
-        Component("YesNoQuestion") {
-            InlinedYesNoQuestion(title, question, NotifyInfo "Wise choice.", NotifyInfo "Why wouldn't you?")
-        }
+        InlinedYesNoQuestion(title, question, NotifyInfo "Wise choice.", NotifyInfo "Why wouldn't you?")
 
     let update msg model =
         match msg with

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -33,29 +33,6 @@ module NotificationsPage =
         | NotificationShown
         | PositionChanged of SelectionChangedEventArgs
 
-    type WindowNotificationManager with
-        member this.Show(content: WidgetBuilder<'msg, 'marker>) =
-            let widget = content.Compile()
-            let widgetDef = WidgetDefinitionStore.get widget.Key
-            let logger = ProgramDefaults.defaultLogger()
-            let syncAction = ViewHelpers.defaultSyncAction
-
-            let treeContext: ViewTreeContext =
-                { CanReuseView = ViewHelpers.canReuseView
-                  GetViewNode = ViewNode.get
-                  GetComponent = Component.get
-                  SetComponent = Component.set
-                  SyncAction = syncAction
-                  Logger = logger
-                  Dispatch = ignore }
-
-            let envContext = new EnvironmentContext(logger)
-
-            let struct (_node, view) =
-                widgetDef.CreateView(widget, envContext, treeContext, ValueNone)
-
-            this.Show(view)
-
     let notifyOneAsync () =
         Cmd.OfAsync.msg(
             async {
@@ -154,9 +131,6 @@ module NotificationsPage =
             createYesNoQuestion "Can you dig it?" "You can use standard widgets in notifications!"
             |> notifyComponent model.NotificationManager
 
-        | ShowCustomManagedNotification ->
-            model, showNotificationContent model.NotificationManager (questionContent "Can you dig it?" "You can use standard widgets in notifications!")
-
         | ShowNativeNotification ->
             model,
             Notification("Error", "Native Notifications are not quite ready. Coming soon.", NotificationType.Error)
@@ -164,10 +138,6 @@ module NotificationsPage =
 
         | ShowAsyncCompletedNotification -> model, notifyOneAsync()
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
-        | ToggleInlinedNotification ->
-            { model with
-                ShowInlined = not model.ShowInlined },
-            Cmd.none
 
         | ToggleInlinedNotification ->
             { model with

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -103,26 +103,9 @@ module NotificationsPage =
           ShowInlined = false },
         []
 
-    type QuestionLocalMsg =
-        | LocalYes
-        | LocalNo
-
-    let questionInit () = (), Cmd.none
-
-    let questionUpdate (msg: QuestionLocalMsg) (model: unit) =
-        let show (title: string) (message: string) : Cmd<QuestionLocalMsg> =
-            Cmd.ofEffect(fun _ -> Dispatcher.UIThread.Post(fun () -> FabApplication.Current.WindowNotificationManager.Show(Notification(title, message))))
-
-        match msg with
-        | LocalYes -> model, show "Wise choice." "You better!"
-        | LocalNo -> model, show "What?" "Why wouldn't you?"
-
-    let questionProgram = Program.statefulWithCmd questionInit questionUpdate
-
-    let createYesNoQuestion title question =
-        Component("QuestionContent") {
-            let! _ = Context.Mvu questionProgram
-            InlinedYesNoQuestion(title, question, QuestionLocalMsg.LocalYes, QuestionLocalMsg.LocalNo)
+    let private createYesNoQuestion title question =
+        Component("YesNoQuestion") {
+            InlinedYesNoQuestion(title, question, NotifyInfo "Wise choice.", NotifyInfo "Why wouldn't you?")
         }
 
     let update msg model =

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -13,7 +13,6 @@ open Fabulous.Avalonia
 
 open type Fabulous.Avalonia.View
 
-
 module NotificationsPage =
     type Model =
         { NotificationManager: WindowNotificationManager
@@ -21,9 +20,9 @@ module NotificationsPage =
           ShowInlined: bool }
 
     type Msg =
-        | ShowPlainNotification
-        | ShowCustomPlainNotification
-        | ShowCustomManagedNotification
+        | ShowBasicNotification
+        | ShowINotification
+        | ShowYesNoNotification
         | ShowNativeNotification
         | ShowAsyncCompletedNotification
         | ShowAsyncStatusNotifications
@@ -91,7 +90,7 @@ module NotificationsPage =
                 notificationManager.Show(notification)
                 dispatch(NotificationShown)))
 
-    let showNotificationContent<'msg, 'marker when 'msg: equality>
+    let notifyComponent<'msg, 'marker when 'msg: equality>
         (notificationManager: WindowNotificationManager)
         (content: WidgetBuilder<'msg, 'marker>)
         : Cmd<'msg> =
@@ -143,7 +142,7 @@ module NotificationsPage =
 
     let questionProgram = Program.statefulWithCmd questionInit questionUpdate
 
-    let questionContent title question =
+    let createYesNoQuestion title question =
         Component("QuestionContent") {
             let! _ = Context.Mvu questionProgram
             InlinedYesNoQuestion(title, question, QuestionLocalMsg.LocalYes, QuestionLocalMsg.LocalNo)
@@ -151,12 +150,12 @@ module NotificationsPage =
 
     let update msg model =
         match msg with
-        | ShowPlainNotification ->
+        | ShowBasicNotification ->
             model,
-            Notification("Welcome", "Avalonia now supports Notifications.", NotificationType.Information)
+            Notification("Avalonia supports basic Notifications", "via the built-in Notification type.", NotificationType.Information)
             |> showNotification model.NotificationManager
 
-        | ShowCustomPlainNotification ->
+        | ShowINotification ->
             model,
             { new INotification with
                 member this.Title = "You can implement custom Notifications"
@@ -167,10 +166,10 @@ module NotificationsPage =
                 member this.Type = NotificationType.Error }
             |> showNotification model.NotificationManager
 
-        | ShowCustomManagedNotification ->
+        | ShowYesNoNotification ->
             model,
-            questionContent "Can you dig it?" "You can use standard widgets in notifications!"
-            |> showNotificationContent model.NotificationManager
+            createYesNoQuestion "Can you dig it?" "You can use standard widgets in notifications!"
+            |> notifyComponent model.NotificationManager
 
         | ShowNativeNotification ->
             model,
@@ -230,19 +229,19 @@ module NotificationsPage =
 
             (Grid() {
                 Dock() {
-                    TextBlock("TopLevel bound notification manager.")
+                    TextBlock("TopLevel bound notification manager")
                         .dock(Dock.Top)
-                        .margin(2.)
+                        .margin(20.)
                         .classes([ "h2" ])
                         .textWrapping(TextWrapping.Wrap)
 
-                    Button("A plain Notification", ShowPlainNotification)
+                    Button("A basic Notification", ShowBasicNotification)
                         .dock(Dock.Top)
 
-                    Button("A custom plain Notification", ShowCustomPlainNotification)
+                    Button("A custom INotification", ShowINotification)
                         .dock(Dock.Top)
 
-                    Button("A Managed Notification with custom content", ShowCustomManagedNotification)
+                    Button("A Managed Notification with custom content", ShowYesNoNotification)
                         .dock(Dock.Top)
 
                     Button("Notify async operation completed", ShowAsyncCompletedNotification)
@@ -254,9 +253,9 @@ module NotificationsPage =
                     Button("Toggle inlined notifications", ToggleInlinedNotification)
                         .dock(Dock.Top)
 
-                    TextBlock("Widget-only notification manager.")
+                    TextBlock("Widget-only notification manager")
                         .dock(Dock.Top)
-                        .margin(2.)
+                        .margin(20.)
                         .classes([ "h2" ])
                         .textWrapping(TextWrapping.Wrap)
 
@@ -277,7 +276,7 @@ module NotificationsPage =
                     })
                         .dock(Dock.Top)
 
-                    (questionContent "Can you believe it?" "You can also roll your own inlined dialogs using standard widgets.")
+                    (createYesNoQuestion "Can you believe it?" "You can also roll your own inlined dialogs using standard widgets.")
                         .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 

--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -284,8 +284,9 @@ module NotificationsPage =
                         .borderBrush(SolidColorBrush(Colors.Blue))
                 }
 
-                // We can use the WindowNotificationManager a widget to be able to have a different WindowNotificationManager than FabApplication.Current.WindowNotificationManager
-                // Allowing you to control ie the Position of a single notification
+                (*  Use the WindowNotificationManager widget to create a NotificationManager
+                    separate from the FabApplication.Current.WindowNotificationManager
+                    allowing you to control e.g. the Position of specific notifications. *)
                 WindowNotificationManager(controlNotificationsRef)
                     .position(model.NotificationPosition)
                     .dock(Dock.Top)

--- a/samples/Gallery/Widgets.fs
+++ b/samples/Gallery/Widgets.fs
@@ -69,7 +69,7 @@ open type Fabulous.Avalonia.View
 module CustomNotificationBuilders =
     type Fabulous.Avalonia.View with
 
-        static member CustomNotification(title: string, message: string, yesCommand: 'msg, noCommand: 'msg) =
+        static member InlinedYesNoQuestion(title: string, message: string, yesCommand: 'msg, noCommand: 'msg) =
             Border(
                 Grid(coldefs = [ Auto; Star ], rowdefs = [ Auto ]) {
                     (Panel() {

--- a/samples/Gallery/Widgets.fs
+++ b/samples/Gallery/Widgets.fs
@@ -1,4 +1,4 @@
-namespace Gallery
+﻿namespace Gallery
 
 open System.Runtime.CompilerServices
 open Avalonia.Media
@@ -73,7 +73,7 @@ module CustomNotificationBuilders =
             Border(
                 Grid(coldefs = [ Auto; Star ], rowdefs = [ Auto ]) {
                     (Panel() {
-                        TextBlock("&#xE115;")
+                        TextBlock("❔")
                             .foreground(SolidColorBrush(Colors.White))
                             .fontWeight(FontWeight.Bold)
                             .fontSize(20.)


### PR DESCRIPTION
follow-up for #291 that @edgarfgp got working (thanks!)
simplifying custom-content notification example
pointing out open issue about `NotificationCard`'s `isClosed` param having no effect