### PR TITLE
fix: update notification card widgets

### DIFF
--- a/samples/Gallery/Pages/NotificationsPage.fs
+++ b/samples/Gallery/Pages/NotificationsPage.fs
@@ -136,7 +136,6 @@ module NotificationsPage =
 
         | ShowAsyncCompletedNotification -> model, notifyOneAsync()
         | ShowAsyncStatusNotifications -> model, notifyAsyncStatusUpdates()
-
         | ToggleInlinedNotification ->
             { model with
                 ShowInlined = not model.ShowInlined },
@@ -150,7 +149,7 @@ module NotificationsPage =
         (*  WindowNotificationManager can't be used immediately after creating it,
             so we need to wait for it to be attached to the visual tree.
             See https://github.com/AvaloniaUI/Avalonia/issues/5442 *)
-        | AttachedToVisualTreeChanged args ->
+        | AttachedToVisualTreeChanged _ ->
             { model with
                 NotificationManager = FabApplication.Current.WindowNotificationManager },
             Cmd.none
@@ -238,24 +237,21 @@ module NotificationsPage =
                         .isVisible(model.ShowInlined)
                         .dock(Dock.Top)
 
-                    //TODO this is always shown - indepedendent of model.ShowInlined. I.e, NotificationCard isClosed flag is not working!
-                    // Demonstrate NotificationCard controlled solely via its IsClosed flag. Avoid .isVisible, which masks the effect.
-                    NotificationCard(not model.ShowInlined, "I was here all along, just hidden!")
-                        //.isVisible(model.ShowInlined) // but if you uncomment this, toggling works!
-                        .size(300., 70.)
-                        .dock(Dock.Top)
-                        .padding(10)
-                        .borderBrush(SolidColorBrush(Colors.Blue))
+                    if model.ShowInlined then
+                        NotificationCard("I was here all along, just hidden!")
+                            .size(300., 70.)
+                            .dock(Dock.Top)
+                            .padding(10)
+                            .borderBrush(SolidColorBrush(Colors.Blue))
                 }
 
                 (*  Use the WindowNotificationManager widget to create a NotificationManager
                     separate from the FabApplication.Current.WindowNotificationManager
-                    allowing you to control e.g. the Position of specific notifications. *)
+                    allowing you to control e.g., the Position of specific notifications. *)
                 WindowNotificationManager(controlNotificationsRef)
                     .position(model.NotificationPosition)
                     .dock(Dock.Top)
                     .maxItems(3)
-
             })
                 .onAttachedToVisualTree(AttachedToVisualTreeChanged)
         }

--- a/src/Fabulous.Avalonia/Views/Controls/Notifications/NotificationCard.Components.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Notifications/NotificationCard.Components.fs
@@ -8,7 +8,7 @@ open Fabulous.Avalonia
 
 module ComponentNotificationCard =
     let NotificationClosed =
-        Attributes.Component.defineEvent "NotificationCard_NotificationClosed" (fun target -> (target :?> NotificationCard).NotificationClosed)
+        Attributes.Component.defineRoutedEvent "NotificationCard_NotificationClosed" NotificationCard.NotificationClosedEvent
 
 type ComponentNotificationCardModifiers =
     /// <summary>Listens to the NotificationCard NotificationClosed event.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/Notifications/NotificationCard.Mvu.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Notifications/NotificationCard.Mvu.fs
@@ -8,7 +8,7 @@ open Fabulous.Avalonia
 
 module MvuNotificationCard =
     let NotificationClosed =
-        Attributes.Mvu.defineEvent "NotificationCard_NotificationClosed" (fun target -> (target :?> NotificationCard).NotificationClosed)
+        Attributes.Mvu.defineRoutedEvent "NotificationCard_NotificationClosed" NotificationCard.NotificationClosedEvent
 
 type MvuNotificationCardModifiers =
     /// <summary>Listens to the NotificationCard NotificationClosed event.</summary>

--- a/src/Fabulous.Avalonia/Views/Controls/Notifications/NotificationCard.fs
+++ b/src/Fabulous.Avalonia/Views/Controls/Notifications/NotificationCard.fs
@@ -3,7 +3,6 @@ namespace Fabulous.Avalonia
 open System.Runtime.CompilerServices
 open Avalonia.Controls.Notifications
 open Fabulous
-open Fabulous.StackAllocatedCollections.StackList
 
 type IFabNotificationCard =
     inherit IFabContentControl
@@ -14,40 +13,22 @@ module NotificationCard =
     let NotificationType =
         Attributes.defineAvaloniaPropertyWithEquality NotificationCard.NotificationTypeProperty
 
-    let IsClosed =
-        Attributes.defineAvaloniaPropertyWithEquality NotificationCard.IsClosedProperty
-
     let CloseOnClick =
         Attributes.defineAvaloniaPropertyWithEquality NotificationCard.CloseOnClickProperty
-
 
 [<AutoOpen>]
 module NotificationCardBuilders =
     type Fabulous.Avalonia.View with
 
         /// <summary>Creates a NotificationCard widget.</summary>
-        /// <param name="isClosed">Whether the NotificationCard is closed.</param>
         /// <param name="content">The content of the NotificationCard.</param>
-        static member NotificationCard(isClosed: bool, content: WidgetBuilder<'msg, #IFabControl>) =
-            WidgetBuilder<'msg, IFabNotificationCard>(
-                NotificationCard.WidgetKey,
-                AttributesBundle(
-                    StackList.one(NotificationCard.IsClosed.WithValue(isClosed)),
-                    [| ContentControl.ContentWidget.WithValue(content.Compile()) |],
-                    [||],
-                    [||]
-                )
-            )
+        static member NotificationCard(content: WidgetBuilder<'msg, #IFabControl>) =
+            WidgetBuilder<'msg, IFabNotificationCard>(NotificationCard.WidgetKey, ContentControl.ContentWidget.WithValue(content.Compile()))
 
         /// <summary>Creates a NotificationCard widget.</summary>
-        /// <param name="isClosed">Whether the NotificationCard is closed.</param>
         /// <param name="content">The content of the NotificationCard.</param>
-        static member NotificationCard(isClosed: bool, content: string) =
-            WidgetBuilder<'msg, IFabNotificationCard>(
-                NotificationCard.WidgetKey,
-                NotificationCard.IsClosed.WithValue(isClosed),
-                ContentControl.ContentString.WithValue(content)
-            )
+        static member NotificationCard(content: string) =
+            WidgetBuilder<'msg, IFabNotificationCard>(NotificationCard.WidgetKey, ContentControl.ContentString.WithValue(content))
 
 type NotificationCardModifiers =
 


### PR DESCRIPTION
Fixes https://github.com/fabulous-dev/Fabulous.Avalonia/pull/292#discussion_r2531746909

- `IsClosed` is a completion state that triggers `NotificationClosed` event; it doesn’t itself hide the card.
- To close visually using the control’s own behaviour, you must call `Close()` (drive `IsClosing`).
- If you only need to show/hide in the sample, prefer `.isVisible(...)` or conditional rendering.

So let's remove `IsClosed` modifier as it is not meant to be used to close the card. Also change NotificationClosed to be a RoutedEvent.
